### PR TITLE
macOSおよびUbuntuビルドステップをコメントアウト

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -71,183 +71,183 @@ jobs:
             echo "pluginName=${plugin_name}" >> $GITHUB_OUTPUT
           fi
 
-  macos-build:
-    name: Build for macOS 🍏
-    runs-on: macos-15
-    needs: check-event
-    defaults:
-      run:
-        shell: zsh --no-rcs --errexit --pipefail {0}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  # macos-build:
+  #   name: Build for macOS 🍏
+  #   runs-on: macos-15
+  #   needs: check-event
+  #   defaults:
+  #     run:
+  #       shell: zsh --no-rcs --errexit --pipefail {0}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - name: Set Up Environment 🔧
-        id: setup
-        run: |
-          : Set Up Environment 🔧
-          if (( ${+RUNNER_DEBUG} )) setopt XTRACE
+  #     - name: Set Up Environment 🔧
+  #       id: setup
+  #       run: |
+  #         : Set Up Environment 🔧
+  #         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          print '::group::Enable Xcode 16.1'
-          sudo xcode-select --switch /Applications/Xcode_16.1.0.app/Contents/Developer
-          print '::endgroup::'
+  #         print '::group::Enable Xcode 16.1'
+  #         sudo xcode-select --switch /Applications/Xcode_16.1.0.app/Contents/Developer
+  #         print '::endgroup::'
 
-          print '::group::Clean Homebrew Environment'
-          local -a unwanted_formulas=()
-          local -a remove_formulas=()
-          for formula (${unwanted_formulas}) {
-            if [[ -d ${HOMEBREW_PREFIX}/Cellar/${formula} ]] remove_formulas+=(${formula})
-          }
+  #         print '::group::Clean Homebrew Environment'
+  #         local -a unwanted_formulas=()
+  #         local -a remove_formulas=()
+  #         for formula (${unwanted_formulas}) {
+  #           if [[ -d ${HOMEBREW_PREFIX}/Cellar/${formula} ]] remove_formulas+=(${formula})
+  #         }
 
-          if (( #remove_formulas )) brew uninstall --ignore-dependencies ${remove_formulas}
-          print '::endgroup::'
+  #         if (( #remove_formulas )) brew uninstall --ignore-dependencies ${remove_formulas}
+  #         print '::endgroup::'
 
-          local product_name
-          local product_version
-          read -r product_name product_version <<< \
-            "$(jq -r '. | {name, version} | join(" ")' buildspec.json)"
+  #         local product_name
+  #         local product_version
+  #         read -r product_name product_version <<< \
+  #           "$(jq -r '. | {name, version} | join(" ")' buildspec.json)"
 
-          print "pluginName=${product_name}" >> $GITHUB_OUTPUT
-          print "pluginVersion=${product_version}" >> $GITHUB_OUTPUT
+  #         print "pluginName=${product_name}" >> $GITHUB_OUTPUT
+  #         print "pluginVersion=${product_version}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v4
-        id: ccache-cache
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-ccache-${{ needs.check-event.outputs.config }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-
+  #     - uses: actions/cache/restore@v4
+  #       id: ccache-cache
+  #       with:
+  #         path: ${{ github.workspace }}/.ccache
+  #         key: ${{ runner.os }}-ccache-${{ needs.check-event.outputs.config }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-ccache-
 
-      - name: Set Up Codesigning 🔑
-        uses: ./.github/actions/setup-macos-codesigning
-        if: fromJSON(needs.check-event.outputs.codesign)
-        id: codesign
-        with:
-          codesignIdentity: ${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}
-          installerIdentity: ${{ secrets.MACOS_SIGNING_INSTALLER_IDENTITY }}
-          codesignCertificate: ${{ secrets.MACOS_SIGNING_CERT }}
-          certificatePassword: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
-          keychainPassword: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-          provisioningProfile: ${{ secrets.MACOS_SIGNING_PROVISIONING_PROFILE }}
-          notarizationUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
-          notarizationPassword: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
+  #     - name: Set Up Codesigning 🔑
+  #       uses: ./.github/actions/setup-macos-codesigning
+  #       if: fromJSON(needs.check-event.outputs.codesign)
+  #       id: codesign
+  #       with:
+  #         codesignIdentity: ${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}
+  #         installerIdentity: ${{ secrets.MACOS_SIGNING_INSTALLER_IDENTITY }}
+  #         codesignCertificate: ${{ secrets.MACOS_SIGNING_CERT }}
+  #         certificatePassword: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
+  #         keychainPassword: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+  #         provisioningProfile: ${{ secrets.MACOS_SIGNING_PROVISIONING_PROFILE }}
+  #         notarizationUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
+  #         notarizationPassword: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
 
-      - name: Build Plugin 🧱
-        uses: ./.github/actions/build-plugin
-        with:
-          target: macos-universal
-          config: ${{ needs.check-event.outputs.config }}
-          codesign: ${{ fromJSON(needs.check-event.outputs.codesign) }}
-          codesignIdent: ${{ steps.codesign.outputs.codesignIdent }}
+  #     - name: Build Plugin 🧱
+  #       uses: ./.github/actions/build-plugin
+  #       with:
+  #         target: macos-universal
+  #         config: ${{ needs.check-event.outputs.config }}
+  #         codesign: ${{ fromJSON(needs.check-event.outputs.codesign) }}
+  #         codesignIdent: ${{ steps.codesign.outputs.codesignIdent }}
 
-      - name: Package Plugin 📀
-        uses: ./.github/actions/package-plugin
-        with:
-          target: macos-universal
-          config: ${{ needs.check-event.outputs.config }}
-          package: ${{ fromJSON(needs.check-event.outputs.package) }}
-          codesign: ${{ fromJSON(needs.check-event.outputs.codesign) && fromJSON(steps.codesign.outputs.haveCodesignIdent) }}
-          codesignIdent: ${{ steps.codesign.outputs.codesignIdent }}
-          installerIdent: ${{ steps.codesign.outputs.installerIdent }}
-          codesignTeam: ${{ steps.codesign.outputs.codesignTeam }}
-          notarize: ${{ fromJSON(needs.check-event.outputs.notarize) && fromJSON(steps.codesign.outputs.haveNotarizationUser) }}
-          codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
-          codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
+  #     - name: Package Plugin 📀
+  #       uses: ./.github/actions/package-plugin
+  #       with:
+  #         target: macos-universal
+  #         config: ${{ needs.check-event.outputs.config }}
+  #         package: ${{ fromJSON(needs.check-event.outputs.package) }}
+  #         codesign: ${{ fromJSON(needs.check-event.outputs.codesign) && fromJSON(steps.codesign.outputs.haveCodesignIdent) }}
+  #         codesignIdent: ${{ steps.codesign.outputs.codesignIdent }}
+  #         installerIdent: ${{ steps.codesign.outputs.installerIdent }}
+  #         codesignTeam: ${{ steps.codesign.outputs.codesignTeam }}
+  #         notarize: ${{ fromJSON(needs.check-event.outputs.notarize) && fromJSON(steps.codesign.outputs.haveNotarizationUser) }}
+  #         codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
+  #         codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
 
-      - name: Upload Artifacts 📡
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal.*
+  #     - name: Upload Artifacts 📡
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal-${{ needs.check-event.outputs.commitHash }}
+  #         path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal.*
 
-      - name: Upload Debug Symbol Artifacts 🪲
-        uses: actions/upload-artifact@v4
-        if: ${{ needs.check-event.outputs.config == 'Release' }}
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal-${{ needs.check-event.outputs.commitHash }}-dSYMs
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal-dSYMs.*
+  #     - name: Upload Debug Symbol Artifacts 🪲
+  #       uses: actions/upload-artifact@v4
+  #       if: ${{ needs.check-event.outputs.config == 'Release' }}
+  #       with:
+  #         name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal-${{ needs.check-event.outputs.commitHash }}-dSYMs
+  #         path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-macos-universal-dSYMs.*
 
-      - uses: actions/cache/save@v4
-        if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-ccache-${{ needs.check-event.outputs.config }}
+  #     - uses: actions/cache/save@v4
+  #       if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
+  #       with:
+  #         path: ${{ github.workspace }}/.ccache
+  #         key: ${{ runner.os }}-ccache-${{ needs.check-event.outputs.config }}
 
-  ubuntu-build:
-    name: Build for Ubuntu 🐧
-    strategy:
-      matrix:
-        os: [ubuntu-24.04]
-    runs-on: ${{ matrix.os }}
-    needs: check-event
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
+  # ubuntu-build:
+  #   name: Build for Ubuntu 🐧
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-24.04]
+  #   runs-on: ${{ matrix.os }}
+  #   needs: check-event
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: recursive
+  #         fetch-depth: 0
 
-      - name: Set Up Environment 🔧
-        id: setup
-        run: |
-          : Set Up Environment 🔧
-          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
+  #     - name: Set Up Environment 🔧
+  #       id: setup
+  #       run: |
+  #         : Set Up Environment 🔧
+  #         if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
-          read -r product_name product_version <<< \
-            "$(jq -r '. | {name, version} | join(" ")' buildspec.json)"
+  #         read -r product_name product_version <<< \
+  #           "$(jq -r '. | {name, version} | join(" ")' buildspec.json)"
 
-          echo "pluginName=${product_name}" >> $GITHUB_OUTPUT
-          echo "pluginVersion=${product_version}" >> $GITHUB_OUTPUT
+  #         echo "pluginName=${product_name}" >> $GITHUB_OUTPUT
+  #         echo "pluginVersion=${product_version}" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache/restore@v4
-        id: ccache-cache
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-${{ needs.check-event.outputs.config }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-
+  #     - uses: actions/cache/restore@v4
+  #       id: ccache-cache
+  #       with:
+  #         path: ${{ github.workspace }}/.ccache
+  #         key: ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-${{ needs.check-event.outputs.config }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-
 
-      - name: Build Plugin 🧱
-        uses: ./.github/actions/build-plugin
-        with:
-          target: x86_64
-          config: ${{ needs.check-event.outputs.config }}
+  #     - name: Build Plugin 🧱
+  #       uses: ./.github/actions/build-plugin
+  #       with:
+  #         target: x86_64
+  #         config: ${{ needs.check-event.outputs.config }}
 
-      - name: Package Plugin 📀
-        uses: ./.github/actions/package-plugin
-        with:
-          target: x86_64
-          config: ${{ needs.check-event.outputs.config }}
-          package: ${{ fromJSON(needs.check-event.outputs.package) }}
+  #     - name: Package Plugin 📀
+  #       uses: ./.github/actions/package-plugin
+  #       with:
+  #         target: x86_64
+  #         config: ${{ needs.check-event.outputs.config }}
+  #         package: ${{ fromJSON(needs.check-event.outputs.package) }}
 
-      - name: Upload Source Tarball 🗜️
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-sources-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-source.*
+  #     - name: Upload Source Tarball 🗜️
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-sources-${{ needs.check-event.outputs.commitHash }}
+  #         path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-source.*
 
-      - name: Upload Artifacts 📡
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-x86_64*.*
+  #     - name: Upload Artifacts 📡
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}
+  #         path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-x86_64*.*
 
-      - name: Upload debug symbol artifacts 🪲
-        uses: actions/upload-artifact@v4
-        if: ${{ fromJSON(needs.check-event.outputs.package) }}
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}-dbgsym
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-x86_64*-dbgsym.ddeb
+  #     - name: Upload debug symbol artifacts 🪲
+  #       uses: actions/upload-artifact@v4
+  #       if: ${{ fromJSON(needs.check-event.outputs.package) }}
+  #       with:
+  #         name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}-dbgsym
+  #         path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-x86_64*-dbgsym.ddeb
 
-      - uses: actions/cache/save@v4
-        if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-${{ needs.check-event.outputs.config }}
+  #     - uses: actions/cache/save@v4
+  #       if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
+  #       with:
+  #         path: ${{ github.workspace }}/.ccache
+  #         key: ${{ runner.os }}-${{ matrix.os }}-ccache-x86_64-${{ needs.check-event.outputs.config }}
 
   windows-build:
     name: Build for Windows 🪟


### PR DESCRIPTION
This pull request comments out the macOS and Ubuntu build jobs in the GitHub Actions workflow configuration file. As a result, automated builds for these platforms will no longer run as part of the CI/CD pipeline, leaving only the Windows build job active.

Build pipeline changes:

* Commented out the entire `macos-build` job, disabling all steps for building, packaging, codesigning, and uploading artifacts for macOS targets in `.github/workflows/build-project.yaml`.
* Commented out the entire `ubuntu-build` job, disabling all steps for building, packaging, and uploading artifacts for Ubuntu targets in `.github/workflows/build-project.yaml`.