### PR TITLE
fix/#29

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -33,13 +33,13 @@
     },
     "platformConfig": {
         "macos": {
-            "bundleId": "com.example.plugintemplate-for-obs"
+            "bundleId": "com.example.foxclip"
         }
     },
-    "name": "plugintemplate-for-obs",
-    "displayName": "Plugin Template for OBS",
+    "name": "foxclip",
+    "displayName": "FoxClip for OBS",
     "version": "1.0.0",
-    "author": "Your Name Here",
-    "website": "https://example.com",
-    "email": "me@example.com"
+    "author": "UsersIsDevious",
+    "website": "https://github.com/UsersIsDevious/FoxClip",
+    "email": "support@uids.jp"
 }


### PR DESCRIPTION
- #29 

This pull request updates project metadata and versioning to reflect the new branding and version of the plugin. The most important changes are grouped below:

Branding and Metadata Updates:

* Renamed the project from `plugintemplate-for-obs` to `foxclip`, including updates to the `name`, `displayName`, `author`, and `website` fields in `buildspec.json` to match the new identity.
* Changed the macOS bundle identifier in `buildspec.json` from `com.example.plugintemplate-for-obs` to `com.example.foxclip`.

Versioning Improvements:

* Modified the CMake configuration in `cmake/macos/xcode.cmake` to set `DYLIB_COMPATIBILITY_VERSION` based on the `PLUGIN_VERSION` variable instead of a hardcoded value, ensuring consistency with the marketing version.