### PR TITLE
Feature/#39

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,6 @@ target_sources(
     src/infra_shared/fs/PathResolver.cpp
     src/infra_shared/fs/FileStore.cpp
     src/infra_shared/startup/EnsurePluginDir.cpp
-    src/public_api/log/FoxclipLogApi.c
 )
 
 target_include_directories(
@@ -78,16 +77,3 @@ target_include_directories(
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME
                              ${_name}
 )
-
-# ===== ローカライズファイルのインストール =====
-# 期待する配置: <repo>/data/obs-plugins/${_name}/locale/en-US.ini, ja-JP.ini, ...
-install(
-  TARGETS ${CMAKE_PROJECT_NAME}
-  RUNTIME
-    DESTINATION
-      "obs-plugins/${_name}" # Windows
-  LIBRARY
-    DESTINATION
-      "obs-plugins/${_name}" # macOS/Linux
-)
-# ===============================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ include(helpers)
 
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE FOXCLIP_BUILDING)
+
 find_package(libobs REQUIRED)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::libobs)
 
@@ -53,12 +55,20 @@ target_sources(
     src/features/startup_check/app/StartupCheckFacade.cpp
     src/features/startup_check/domain/StartupCheckService.cpp
     src/features/startup_check/infrastructure/StdFsDirectoryChecker.cpp
+    src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
+    src/infra_shared/config/path/ObsConfigPathProvider.cpp
     src/infra_shared/log/ObsLogger.c
+    src/public_api/log/FoxclipLogApi.c
 )
 
 target_include_directories(
   ${CMAKE_PROJECT_NAME}
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR}/generated
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_BINARY_DIR}/generated
 )
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME
                              ${_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,12 +67,8 @@ target_sources(
 
 target_include_directories(
   ${CMAKE_PROJECT_NAME}
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CMAKE_CURRENT_BINARY_DIR}/generated
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR}/generated
 )
 set_target_properties_plugin(${CMAKE_PROJECT_NAME} PROPERTIES OUTPUT_NAME
                              ${_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ target_sources(
     src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
     src/infra_shared/config/path/ObsConfigPathProvider.cpp
     src/infra_shared/log/ObsLogger.c
+    src/infra_shared/fs/FsUtils.cpp
+    src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+    src/infra_shared/fs/PathResolver.cpp
+    src/infra_shared/fs/FileStore.cpp
+    src/infra_shared/startup/EnsurePluginDir.cpp
     src/public_api/log/FoxclipLogApi.c
 )
 

--- a/print_code_tree.bat
+++ b/print_code_tree.bat
@@ -1,0 +1,9 @@
+@echo off
+rem 現在のフォルダ名を取得
+for %%P in (.) do set CURNAME=%%~nxP
+
+echo %CURNAME%
+echo +--- src
+for /f "usebackq delims=" %%L in (`tree "src" /A /F ^| more +3`) do @echo ^|   %%L
+echo \--- include
+for /f "usebackq delims=" %%L in (`tree "include" /A /F ^| more +3`) do @echo      %%L

--- a/src/app/plugin-main.cpp
+++ b/src/app/plugin-main.cpp
@@ -20,7 +20,7 @@ bool obs_module_load(void)
 	using foxclip::startup_check::infrastructure::StdFsDirectoryChecker;
 
 	auto checker = std::make_unique<StdFsDirectoryChecker>();
-	StartupCheckFacade facade(std::move(checker),"foxclip-plugins");
+	StartupCheckFacade facade(std::move(checker), "foxclip-plugins");
 	auto r = facade.run();
 	if (!r.ok) {
 		// Log error Directory does not exist

--- a/src/app/plugin-main.cpp
+++ b/src/app/plugin-main.cpp
@@ -20,7 +20,7 @@ bool obs_module_load(void)
 	using foxclip::features::startup_check::infrastructure::StdFsDirectoryChecker;
 
 	auto checker = std::make_unique<StdFsDirectoryChecker>();
-	StartupCheckFacade facade(std::move(checker), ".", "foxclip-plugins");
+	StartupCheckFacade facade(std::move(checker),"foxclip-plugins");
 	auto r = facade.run();
 	if (!r.ok) {
 		// Log error Directory does not exist

--- a/src/app/plugin-main.cpp
+++ b/src/app/plugin-main.cpp
@@ -16,8 +16,8 @@ bool obs_module_load(void)
 	OBS_LOG_INFO("plugin loaded successfully (version %s)", PLUGIN_VERSION);
 
 	//checking plugins directory
-	using foxclip::features::startup_check::app::StartupCheckFacade;
-	using foxclip::features::startup_check::infrastructure::StdFsDirectoryChecker;
+	using foxclip::startup_check::app::StartupCheckFacade;
+	using foxclip::startup_check::infrastructure::StdFsDirectoryChecker;
 
 	auto checker = std::make_unique<StdFsDirectoryChecker>();
 	StartupCheckFacade facade(std::move(checker),"foxclip-plugins");

--- a/src/features/startup_check/app/StartupCheckFacade.cpp
+++ b/src/features/startup_check/app/StartupCheckFacade.cpp
@@ -15,13 +15,13 @@ StartupCheckFacade::StartupCheckFacade(std::unique_ptr<domain::IDirectoryChecker
 
 	if (er.ok && !er.fullPath.empty()) {
 		// StartupCheckService へは「requiredName=フルパス」「basePath=""」で渡す
-		service = std::make_unique<domain::StartupCheckService>(*dirChecker.get(), domain::DirectoryPolicy{er.fullPath},
-									"", creator);
+		service = std::make_unique<domain::StartupCheckService>(
+			*dirChecker.get(), domain::DirectoryPolicy{er.fullPath}, "", creator);
 		OBS_LOG_INFO("[foxclip] using OBS config dir: %s", er.fullPath.c_str());
 	} else {
 		// フォールバック（相対パスで '.' / 実際の作成は service.run() に委ねる）
-		service = std::make_unique<domain::StartupCheckService>(*dirChecker.get(), domain::DirectoryPolicy{requiredName},
-									".", creator);
+		service = std::make_unique<domain::StartupCheckService>(
+			*dirChecker.get(), domain::DirectoryPolicy{requiredName}, ".", creator);
 
 		const std::string errorMsg = er.errorMessage.empty() ? "failed to ensure obs dir" : er.errorMessage;
 

--- a/src/features/startup_check/app/StartupCheckFacade.cpp
+++ b/src/features/startup_check/app/StartupCheckFacade.cpp
@@ -13,17 +13,17 @@ StartupCheckFacade::StartupCheckFacade(std::unique_ptr<domain::IDirectoryChecker
 	using foxclip::infra_shared::startup::ensure_obs_writable_dir;
 	const auto er = ensure_obs_writable_dir(requiredName);
 
-	if (er.ok && !er.full_path.empty()) {
+	if (er.ok && !er.fullPath.empty()) {
 		// StartupCheckService へは「requiredName=フルパス」「basePath=""」で渡す
 		service_ = std::make_unique<domain::StartupCheckService>(
-			*checker_, domain::DirectoryPolicy{er.full_path}, "", creator_);
-		OBS_LOG_INFO("[foxclip] using OBS config dir: %s", er.full_path.c_str());
+			*checker_, domain::DirectoryPolicy{er.fullPath}, "", creator_);
+		OBS_LOG_INFO("[foxclip] using OBS config dir: %s", er.fullPath.c_str());
 	} else {
 		// フォールバック（相対パスで '.' / 実際の作成は service_.run() に委ねる）
 		service_ = std::make_unique<domain::StartupCheckService>(
 			*checker_, domain::DirectoryPolicy{requiredName}, ".", creator_);
 		OBS_LOG_WARN("[foxclip] %s; fallback to ./'%s'",
-			     er.error_message.empty() ? "failed to ensure obs dir" : er.error_message.c_str(),
+			     er.errorMessage.empty() ? "failed to ensure obs dir" : er.errorMessage.c_str(),
 			     requiredName.c_str());
 	}
 }

--- a/src/features/startup_check/app/StartupCheckFacade.cpp
+++ b/src/features/startup_check/app/StartupCheckFacade.cpp
@@ -22,9 +22,10 @@ StartupCheckFacade::StartupCheckFacade(std::unique_ptr<domain::IDirectoryChecker
 		// フォールバック（相対パスで '.' / 実際の作成は service_.run() に委ねる）
 		service_ = std::make_unique<domain::StartupCheckService>(
 			*checker_, domain::DirectoryPolicy{requiredName}, ".", creator_);
-		OBS_LOG_WARN("[foxclip] %s; fallback to ./'%s'",
-			     er.errorMessage.empty() ? "failed to ensure obs dir" : er.errorMessage.c_str(),
-			     requiredName.c_str());
+
+		const std::string error_msg = er.errorMessage.empty() ? "failed to ensure obs dir" : er.errorMessage;
+
+		OBS_LOG_WARN("[foxclip] %s; fallback to ./'%s'", error_msg.c_str(), requiredName.c_str());
 	}
 }
 

--- a/src/features/startup_check/app/StartupCheckFacade.cpp
+++ b/src/features/startup_check/app/StartupCheckFacade.cpp
@@ -1,18 +1,39 @@
 #include "StartupCheckFacade.h"
 #include "infra_shared/log/ObsLogger.h"
+#include "infra_shared/config/path/ObsConfigPathProvider.h"
+#include <memory>
 
-namespace foxclip::features::startup_check::app {
+namespace foxclip::startup_check::app {
 
-StartupCheckFacade::StartupCheckFacade(std::unique_ptr<foxclip::domain::IDirectoryChecker> checker,
+StartupCheckFacade::StartupCheckFacade(std::unique_ptr<foxclip::startup_check::domain::IDirectoryChecker> checker,
 				       std::string basePath, std::string requiredName)
 	: checker_(std::move(checker)),
-	  service_(*checker_, {std::move(requiredName)}, std::move(basePath))
+	  creator_()
+{
+	// OBS の書き込み可能ディレクトリに解決
+	using foxclip::infra_shared::config::path::MakeObsConfigPathProvider;
+	auto provider = MakeObsConfigPathProvider();
+	const std::string full = provider->config_path(requiredName);
+	if (!full.empty()) {
+		service_ = std::make_unique<foxclip::startup_check::domain::StartupCheckService>(
+			*checker_, foxclip::startup_check::domain::DirectoryPolicy{full}, "", creator_);
+		OBS_LOG_INFO("[foxclip] using OBS config dir: %s", full.c_str());
+	} else {
+		service_ = std::make_unique<foxclip::startup_check::domain::StartupCheckService>(
+			*checker_, foxclip::startup_check::domain::DirectoryPolicy{requiredName}, basePath, creator_);
+		OBS_LOG_WARN("[foxclip] failed to get OBS config dir; fallback to basePath='%s', name='%s'",
+			     basePath.c_str(), requiredName.c_str());
+	}
+}
+
+StartupCheckFacade::StartupCheckFacade(std::unique_ptr<domain::IDirectoryChecker> checker, std::string requiredName)
+	: StartupCheckFacade(std::move(checker), "", std::move(requiredName))
 {
 }
 
-foxclip::domain::Result StartupCheckFacade::run()
+foxclip::startup_check::domain::Result StartupCheckFacade::run()
 {
-	auto res = service_.run();
+	auto res = service_->run();
 	if (res.ok)
 		OBS_LOG_INFO("%s", res.message.c_str());
 	else
@@ -20,4 +41,4 @@ foxclip::domain::Result StartupCheckFacade::run()
 	return res;
 }
 
-} // namespace foxclip::features::startup_check::app
+} // namespace foxclip::startup_check::app

--- a/src/features/startup_check/app/StartupCheckFacade.h
+++ b/src/features/startup_check/app/StartupCheckFacade.h
@@ -1,17 +1,21 @@
 #pragma once
 #include "features/startup_check/domain/StartupCheckService.h"
 #include "features/startup_check/infrastructure/StdFsDirectoryChecker.h"
+#include "features/startup_check/infrastructure/StdFsDirectoryCreator.h"
 
-namespace foxclip::features::startup_check::app {
+namespace foxclip::startup_check::app {
 
 class StartupCheckFacade {
 public:
-	StartupCheckFacade(std::unique_ptr<foxclip::domain::IDirectoryChecker> checker, std::string basePath,
-			   std::string requiredName);
-	foxclip::domain::Result run(); // ログ出力やエラー整形もここで
+	StartupCheckFacade(std::unique_ptr<foxclip::startup_check::domain::IDirectoryChecker> checker,
+			   std::string basePath, std::string requiredName);
+	// basePath 省略版 (デフォルトで "")
+	StartupCheckFacade(std::unique_ptr<domain::IDirectoryChecker> checker, std::string requiredName);
+	foxclip::startup_check::domain::Result run(); // ログ出力やエラー整形もここで
 private:
-	std::unique_ptr<foxclip::domain::IDirectoryChecker> checker_;
-	foxclip::domain::StartupCheckService service_;
+	std::unique_ptr<foxclip::startup_check::domain::IDirectoryChecker> checker_;
+	foxclip::startup_check::infrastructure::StdFsDirectoryCreator creator_;
+	std::unique_ptr<foxclip::startup_check::domain::StartupCheckService> service_;
 };
 
-} // namespace foxclip::features::startup_check::app
+} // namespace foxclip::startup_check::app

--- a/src/features/startup_check/app/StartupCheckFacade.h
+++ b/src/features/startup_check/app/StartupCheckFacade.h
@@ -11,9 +11,9 @@ public:
 	StartupCheckFacade(std::unique_ptr<domain::IDirectoryChecker> checker, std::string requiredName);
 	foxclip::startup_check::domain::Result run(); // ログ出力やエラー整形もここで
 private:
-	std::unique_ptr<foxclip::startup_check::domain::IDirectoryChecker> checker_;
-	foxclip::startup_check::infrastructure::StdFsDirectoryCreator creator_;
-	std::unique_ptr<foxclip::startup_check::domain::StartupCheckService> service_;
+	std::unique_ptr<foxclip::startup_check::domain::IDirectoryChecker> dirChecker;
+	foxclip::startup_check::infrastructure::StdFsDirectoryCreator creator;
+	std::unique_ptr<foxclip::startup_check::domain::StartupCheckService> service;
 };
 
 } // namespace foxclip::startup_check::app

--- a/src/features/startup_check/app/StartupCheckFacade.h
+++ b/src/features/startup_check/app/StartupCheckFacade.h
@@ -7,9 +7,7 @@ namespace foxclip::startup_check::app {
 
 class StartupCheckFacade {
 public:
-	StartupCheckFacade(std::unique_ptr<foxclip::startup_check::domain::IDirectoryChecker> checker,
-			   std::string basePath, std::string requiredName);
-	// basePath 省略版 (デフォルトで "")
+	// 起動時に作る/確認するサブディレクトリ名だけ受け取る（例: "foxclip-plugins"）
 	StartupCheckFacade(std::unique_ptr<domain::IDirectoryChecker> checker, std::string requiredName);
 	foxclip::startup_check::domain::Result run(); // ログ出力やエラー整形もここで
 private:

--- a/src/features/startup_check/domain/DirectoryCreator.h
+++ b/src/features/startup_check/domain/DirectoryCreator.h
@@ -11,7 +11,7 @@ public:
 
 	/// 成功: true / 既に存在でも true
 	/// 失敗: false（error_code に詳細）
-	virtual bool create_if_missing(const std::string &path, std::error_code &ec) = 0;
+	virtual bool createIfMissing(const std::string &path, std::error_code &ec) = 0;
 };
 
 } // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/domain/DirectoryCreator.h
+++ b/src/features/startup_check/domain/DirectoryCreator.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <string>
+#include <system_error>
+
+namespace foxclip::startup_check::domain {
+
+/// ディレクトリを（必要なら親も含めて）作成する最小インターフェース
+class DirectoryCreator {
+public:
+	virtual ~DirectoryCreator() = default;
+
+	/// 成功: true / 既に存在でも true
+	/// 失敗: false（error_code に詳細）
+	virtual bool create_if_missing(const std::string &path, std::error_code &ec) = 0;
+};
+
+} // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/domain/DirectoryPolicy.h
+++ b/src/features/startup_check/domain/DirectoryPolicy.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <string>
 
-namespace foxclip::domain {
+namespace foxclip::startup_check::domain {
 struct DirectoryPolicy {
 	std::string requiredName;
 };
-} // namespace foxclip::domain
+} // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/domain/Result.h
+++ b/src/features/startup_check/domain/Result.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 
-namespace foxclip::domain {
+namespace foxclip::startup_check::domain {
 
 struct Result {
 	bool ok;
@@ -10,4 +10,4 @@ struct Result {
 	static Result failure(std::string msg) { return {false, std::move(msg)}; }
 };
 
-} // namespace foxclip::domain
+} // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/domain/StartupCheckService.cpp
+++ b/src/features/startup_check/domain/StartupCheckService.cpp
@@ -1,22 +1,43 @@
 #include <filesystem>
 #include "StartupCheckService.h"
 
-namespace foxclip::domain {
+namespace foxclip::startup_check::domain {
 
-StartupCheckService::StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath)
+StartupCheckService::StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath,
+					 DirectoryCreator &creator)
 	: checker_(checker),
 	  policy_(std::move(policy)),
-	  basePath_(std::move(basePath))
+	  basePath_(std::move(basePath)),
+	  creator_(creator)
 {
 }
 
-Result StartupCheckService::run() const
+Result StartupCheckService::run()
 {
-	std::string target = (std::filesystem::path(basePath_) / policy_.requiredName).string();
+	// basePath_ が空なら requiredName を「そのままフルパス」として扱う
+	std::filesystem::path targetPath = basePath_.empty()
+						   ? std::filesystem::path(policy_.requiredName)
+						   : (std::filesystem::path(basePath_) / policy_.requiredName);
+	std::string target = targetPath.string();
 	if (!checker_.existsDir(target)) {
-		return Result::failure("必須ディレクトリ '" + policy_.requiredName + "' が存在しません");
+		// 無ければ作成を試みる
+		std::error_code ec;
+		const bool ok = creator_.create_if_missing(target, ec);
+		if (!ok) {
+			if (ec) {
+				return Result::failure("必須ディレクトリ '" + policy_.requiredName +
+						       "' の作成に失敗: " + ec.message());
+			}
+			return Result::failure("必須ディレクトリ '" + policy_.requiredName + "' の作成に失敗");
+		}
+		// 念のため再チェック
+		if (!checker_.existsDir(target)) {
+			return Result::failure("必須ディレクトリ '" + policy_.requiredName +
+					       "' を作成後に確認できませんでした");
+		}
+		return Result::success("必須ディレクトリ '" + policy_.requiredName + "' を新規作成しました");
 	}
 	return Result::success("必須ディレクトリ '" + policy_.requiredName + "' が存在します");
 }
 
-} // namespace foxclip::domain
+} // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/domain/StartupCheckService.cpp
+++ b/src/features/startup_check/domain/StartupCheckService.cpp
@@ -5,39 +5,41 @@ namespace foxclip::startup_check::domain {
 
 StartupCheckService::StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath,
 					 DirectoryCreator &creator)
-	: checker_(checker),
-	  policy_(std::move(policy)),
-	  basePath_(std::move(basePath)),
-	  creator_(creator)
+	: checker(checker),
+	  policy(std::move(policy)),
+	  basePath(std::move(basePath)),
+	  creator(creator)
 {
 }
 
 Result StartupCheckService::run()
 {
 	// basePath_ が空なら requiredName を「そのままフルパス」として扱う
-	std::filesystem::path targetPath = basePath_.empty()
-						   ? std::filesystem::path(policy_.requiredName)
-						   : (std::filesystem::path(basePath_) / policy_.requiredName);
+	std::filesystem::path targetPath = basePath.empty() ? std::filesystem::path(policy.requiredName)
+							    : (std::filesystem::path(basePath) / policy.requiredName);
 	std::string target = targetPath.string();
-	if (!checker_.existsDir(target)) {
+	if (!&checker) {
+		return Result::failure("IDirectoryChecker is null");
+	}
+	if (!checker.existsDir(target)) {
 		// 無ければ作成を試みる
 		std::error_code ec;
-		const bool ok = creator_.create_if_missing(target, ec);
+		const bool ok = creator.createIfMissing(target, ec);
 		if (!ok) {
 			if (ec) {
-				return Result::failure("必須ディレクトリ '" + policy_.requiredName +
+				return Result::failure("必須ディレクトリ '" + policy.requiredName +
 						       "' の作成に失敗: " + ec.message());
 			}
-			return Result::failure("必須ディレクトリ '" + policy_.requiredName + "' の作成に失敗");
+			return Result::failure("必須ディレクトリ '" + policy.requiredName + "' の作成に失敗");
 		}
 		// 念のため再チェック
-		if (!checker_.existsDir(target)) {
-			return Result::failure("必須ディレクトリ '" + policy_.requiredName +
+		if (!checker.existsDir(target)) {
+			return Result::failure("必須ディレクトリ '" + policy.requiredName +
 					       "' を作成後に確認できませんでした");
 		}
-		return Result::success("必須ディレクトリ '" + policy_.requiredName + "' を新規作成しました");
+		return Result::success("必須ディレクトリ '" + policy.requiredName + "' を新規作成しました");
 	}
-	return Result::success("必須ディレクトリ '" + policy_.requiredName + "' が存在します");
+	return Result::success("必須ディレクトリ '" + policy.requiredName + "' が存在します");
 }
 
 } // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/domain/StartupCheckService.h
+++ b/src/features/startup_check/domain/StartupCheckService.h
@@ -12,8 +12,6 @@ struct IDirectoryChecker {
 
 class StartupCheckService {
 public:
-	//StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath);
-	//Result run() const;
 	StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath,
 			    DirectoryCreator &creator);
 	Result run();

--- a/src/features/startup_check/domain/StartupCheckService.h
+++ b/src/features/startup_check/domain/StartupCheckService.h
@@ -17,10 +17,10 @@ public:
 	Result run();
 
 private:
-	const IDirectoryChecker &checker_;
-	DirectoryPolicy policy_;
-	std::string basePath_;
-	DirectoryCreator &creator_;
+	const IDirectoryChecker &checker;
+	DirectoryPolicy policy;
+	std::string basePath;
+	DirectoryCreator &creator;
 };
 
 } // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/domain/StartupCheckService.h
+++ b/src/features/startup_check/domain/StartupCheckService.h
@@ -1,8 +1,9 @@
 #pragma once
 #include "Result.h"
 #include "DirectoryPolicy.h"
+#include "DirectoryCreator.h"
 
-namespace foxclip::domain {
+namespace foxclip::startup_check::domain {
 
 struct IDirectoryChecker {
 	virtual ~IDirectoryChecker() = default;
@@ -11,13 +12,17 @@ struct IDirectoryChecker {
 
 class StartupCheckService {
 public:
-	StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath);
-	Result run() const;
+	//StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath);
+	//Result run() const;
+	StartupCheckService(const IDirectoryChecker &checker, DirectoryPolicy policy, std::string basePath,
+			    DirectoryCreator &creator);
+	Result run();
 
 private:
 	const IDirectoryChecker &checker_;
 	DirectoryPolicy policy_;
 	std::string basePath_;
+	DirectoryCreator &creator_;
 };
 
-} // namespace foxclip::domain
+} // namespace foxclip::startup_check::domain

--- a/src/features/startup_check/infrastructure/StdFsDirectoryChecker.cpp
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryChecker.cpp
@@ -18,4 +18,4 @@ bool StdFsDirectoryChecker::existsDir(const std::string &path) const
 	return fs::is_directory(st);
 }
 
-} // namespace foxclip::features::startup_check::infrastructure
+} // namespace foxclip::startup_check::infrastructure

--- a/src/features/startup_check/infrastructure/StdFsDirectoryChecker.cpp
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryChecker.cpp
@@ -1,7 +1,7 @@
 #include "StdFsDirectoryChecker.h"
 #include "infra_shared/log/ObsLogger.h" // OBS_LOG_ERROR など
 
-namespace foxclip::features::startup_check::infrastructure {
+namespace foxclip::startup_check::infrastructure {
 
 bool StdFsDirectoryChecker::existsDir(const std::string &path) const
 {

--- a/src/features/startup_check/infrastructure/StdFsDirectoryChecker.h
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryChecker.h
@@ -2,11 +2,11 @@
 #include "features/startup_check/domain/StartupCheckService.h"
 #include <filesystem>
 
-namespace foxclip::features::startup_check::infrastructure {
+namespace foxclip::startup_check::infrastructure {
 
-class StdFsDirectoryChecker : public foxclip::domain::IDirectoryChecker {
+class StdFsDirectoryChecker : public foxclip::startup_check::domain::IDirectoryChecker {
 public:
 	bool existsDir(const std::string &path) const override;
 };
 
-} // namespace foxclip::features::startup_check::infrastructure
+} // namespace foxclip::startup_check::infrastructure

--- a/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
@@ -5,7 +5,7 @@ namespace fs = std::filesystem;
 
 namespace foxclip::startup_check::infrastructure {
 
-bool StdFsDirectoryCreator::create_if_missing(const std::string &path, std::error_code &ec)
+bool StdFsDirectoryCreator::createIfMissing(const std::string &path, std::error_code &ec)
 {
 	ec.clear();
 	// 既にある場合は true を返す（何もしない）

--- a/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
@@ -12,7 +12,13 @@ bool StdFsDirectoryCreator::create_if_missing(const std::string &path, std::erro
 	if (fs::exists(path, ec)) {
 		if (ec)
 			return false;
-		return true;
+		if (fs::is_directory(path, ec))
+			return true;
+
+		// 存在はするがディレクトリではない
+		if (!ec)
+			ec = std::make_error_code(std::errc::file_exists);
+		return false;
 	}
 	// 足りない親までまとめて作成
 	const bool ok = fs::create_directories(path, ec);

--- a/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
@@ -1,0 +1,26 @@
+#include "StdFsDirectoryCreator.h"
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+namespace foxclip::startup_check::infrastructure {
+
+bool StdFsDirectoryCreator::create_if_missing(const std::string &path, std::error_code &ec)
+{
+	ec.clear();
+	// 既にある場合は true を返す（何もしない）
+	if (fs::exists(path, ec)) {
+		if (ec)
+			return false;
+		return true;
+	}
+	// 足りない親までまとめて作成
+	const bool ok = fs::create_directories(path, ec);
+	if (ec)
+		return false;
+	// create_directories は「作ったら true / 既存なら false」を返すが、
+	// 我々の API としては「存在すれば成功」で良いので true を返す
+	return ok || fs::exists(path, ec);
+}
+
+} // namespace foxclip::startup_check::infrastructure

--- a/src/features/startup_check/infrastructure/StdFsDirectoryCreator.h
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryCreator.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "features/startup_check/domain/DirectoryCreator.h"
+
+namespace foxclip::startup_check::infrastructure {
+
+using foxclip::startup_check::domain::DirectoryCreator;
+
+class StdFsDirectoryCreator final : public DirectoryCreator {
+public:
+	bool create_if_missing(const std::string &path, std::error_code &ec) override;
+};
+
+} // namespace foxclip::startup_check::infrastructure

--- a/src/features/startup_check/infrastructure/StdFsDirectoryCreator.h
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryCreator.h
@@ -7,7 +7,7 @@ using foxclip::startup_check::domain::DirectoryCreator;
 
 class StdFsDirectoryCreator final : public DirectoryCreator {
 public:
-	bool create_if_missing(const std::string &path, std::error_code &ec) override;
+	bool createIfMissing(const std::string &path, std::error_code &ec) override;
 };
 
 } // namespace foxclip::startup_check::infrastructure

--- a/src/infra_shared/config/path/ObsConfigPathProvider.cpp
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.cpp
@@ -1,25 +1,28 @@
 #include "ObsConfigPathProvider.h"
-#include <obs-module.h>   // obs_module_config_path
+#include <obs-module.h>    // obs_module_config_path
 #include <util/platform.h> // bfree
-#include <memory> 
+#include <memory>
 
 namespace foxclip::infra_shared::config::path {
 
 class ObsConfigPathProvider final : public IConfigPathProvider {
 public:
-  std::string config_path(const std::string& subdir) override {
-    const char* arg = subdir.empty() ? nullptr : subdir.c_str();
-    char* raw = obs_module_config_path(arg);
-    if (!raw) return {};
-    std::string path(raw);
-    bfree(raw);
-    return path;
-  }
+	std::string config_path(const std::string &subdir) override
+	{
+		const char *arg = subdir.empty() ? nullptr : subdir.c_str();
+		char *raw = obs_module_config_path(arg);
+		if (!raw)
+			return {};
+		std::string path(raw);
+		bfree(raw);
+		return path;
+	}
 };
 
 // 生成ヘルパ（必要なら）
-std::unique_ptr<IConfigPathProvider> MakeObsConfigPathProvider() {
-  return std::make_unique<ObsConfigPathProvider>();
+std::unique_ptr<IConfigPathProvider> MakeObsConfigPathProvider()
+{
+	return std::make_unique<ObsConfigPathProvider>();
 }
 
-} // namespace foxclip::infra_shared::config
+} // namespace foxclip::infra_shared::config::path

--- a/src/infra_shared/config/path/ObsConfigPathProvider.cpp
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.cpp
@@ -1,0 +1,25 @@
+#include "ObsConfigPathProvider.h"
+#include <obs-module.h>   // obs_module_config_path
+#include <util/platform.h> // bfree
+#include <memory> 
+
+namespace foxclip::infra_shared::config::path {
+
+class ObsConfigPathProvider final : public IConfigPathProvider {
+public:
+  std::string config_path(const std::string& subdir) override {
+    const char* arg = subdir.empty() ? nullptr : subdir.c_str();
+    char* raw = obs_module_config_path(arg);
+    if (!raw) return {};
+    std::string path(raw);
+    bfree(raw);
+    return path;
+  }
+};
+
+// 生成ヘルパ（必要なら）
+std::unique_ptr<IConfigPathProvider> MakeObsConfigPathProvider() {
+  return std::make_unique<ObsConfigPathProvider>();
+}
+
+} // namespace foxclip::infra_shared::config

--- a/src/infra_shared/config/path/ObsConfigPathProvider.cpp
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.cpp
@@ -7,7 +7,7 @@ namespace foxclip::infra_shared::config::path {
 
 class ObsConfigPathProvider final : public IConfigPathProvider {
 public:
-	std::string config_path(const std::string &subdir) override
+	std::string configPath(const std::string &subdir) override
 	{
 		const char *arg = subdir.empty() ? nullptr : subdir.c_str();
 		char *raw = obs_module_config_path(arg);

--- a/src/infra_shared/config/path/ObsConfigPathProvider.cpp
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.cpp
@@ -20,7 +20,7 @@ public:
 };
 
 // 生成ヘルパ（必要なら）
-std::unique_ptr<IConfigPathProvider> MakeObsConfigPathProvider()
+std::unique_ptr<IConfigPathProvider> makeObsConfigPathProvider()
 {
 	return std::make_unique<ObsConfigPathProvider>();
 }

--- a/src/infra_shared/config/path/ObsConfigPathProvider.h
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.h
@@ -11,7 +11,7 @@ public:
 
 	// arg が空ならモジュールのルート、非空ならそのサブディレクトリのフルパス
 	// 取得に失敗したら空文字を返す（例外は投げない）
-	virtual std::string config_path(const std::string &subdir) = 0;
+	virtual std::string configPath(const std::string &subdir) = 0;
 };
 
 std::unique_ptr<IConfigPathProvider> makeObsConfigPathProvider();

--- a/src/infra_shared/config/path/ObsConfigPathProvider.h
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <string>
+
+namespace foxclip::infra_shared::config::path {
+
+// 「プラグインの書き込み可能な設定ディレクトリ」を返す
+class IConfigPathProvider {
+public:
+  virtual ~IConfigPathProvider() = default;
+
+  // arg が空ならモジュールのルート、非空ならそのサブディレクトリのフルパス
+  // 取得に失敗したら空文字を返す（例外は投げない）
+  virtual std::string config_path(const std::string& subdir) = 0;
+};
+
+} // namespace foxclip::infra_shared::config

--- a/src/infra_shared/config/path/ObsConfigPathProvider.h
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.h
@@ -1,16 +1,19 @@
 #pragma once
 #include <string>
+#include <memory>
 
 namespace foxclip::infra_shared::config::path {
 
 // 「プラグインの書き込み可能な設定ディレクトリ」を返す
 class IConfigPathProvider {
 public:
-  virtual ~IConfigPathProvider() = default;
+	virtual ~IConfigPathProvider() = default;
 
-  // arg が空ならモジュールのルート、非空ならそのサブディレクトリのフルパス
-  // 取得に失敗したら空文字を返す（例外は投げない）
-  virtual std::string config_path(const std::string& subdir) = 0;
+	// arg が空ならモジュールのルート、非空ならそのサブディレクトリのフルパス
+	// 取得に失敗したら空文字を返す（例外は投げない）
+	virtual std::string config_path(const std::string &subdir) = 0;
 };
 
-} // namespace foxclip::infra_shared::config
+std::unique_ptr<IConfigPathProvider> MakeObsConfigPathProvider();
+
+} // namespace foxclip::infra_shared::config::path

--- a/src/infra_shared/config/path/ObsConfigPathProvider.h
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.h
@@ -14,6 +14,6 @@ public:
 	virtual std::string config_path(const std::string &subdir) = 0;
 };
 
-std::unique_ptr<IConfigPathProvider> MakeObsConfigPathProvider();
+std::unique_ptr<IConfigPathProvider> makeObsConfigPathProvider();
 
 } // namespace foxclip::infra_shared::config::path

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -68,7 +68,7 @@ bool FileStore::exists(const std::string &rel, std::error_code &ec) const
 		ec = std::make_error_code(std::errc::invalid_argument);
 		return false;
 	}
-	return exists_dir(full, ec) || std::filesystem::exists(full, ec);
+	return std::filesystem::exists(full, ec);
 }
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -60,7 +60,7 @@ bool FileStore::write_text(const std::string &rel, const std::string &utf8, std:
 		return false;
 	}
 	// 明示的にフラッシュ
-	// (std::ofstream は自動でフラッシュしないので、書き込み後に明示的に呼ぶ)
+	// デストラクタが呼ばれる前に書き込みをディスクに反映させるため、明示的にフラッシュ
 	ofs.flush();
 	if (!ofs.good()) {
 		ec = std::make_error_code(std::errc::io_error);

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -6,11 +6,11 @@
 namespace stdfs = std::filesystem;
 namespace foxclip::infra_shared::fs {
 
-bool FileStore::resolve_path(const std::string &rel, std::string &full, std::error_code &ec) const
+bool FileStore::resolvePath(const std::string &rel, std::string &full, std::error_code &ec) const
 {
 	ec.clear();
 	// 相対パスを OBS ルートと結合してフルパスを取得
-	if (auto fullOpt = resolver_.to_full(rel)) {
+	if (auto fullOpt = resolver.toFull(rel)) {
 		full = *fullOpt;
 		return true;
 	}
@@ -18,31 +18,31 @@ bool FileStore::resolve_path(const std::string &rel, std::string &full, std::err
 	return false;
 }
 
-bool FileStore::ensure_dir(const std::string &relDir, std::error_code &ec)
+bool FileStore::ensureDir(const std::string &relDir, std::error_code &ec)
 {
 	ec.clear();
 
 	// パス解決
 	std::string full;
-	if (!resolve_path(relDir, full, ec))
+	if (!resolvePath(relDir, full, ec))
 		return false;
 
 	// 既に存在するか確認
-	return create_dirs(full, ec);
+	return createDirs(full, ec);
 }
 
-bool FileStore::write_text(const std::string &rel, const std::string &utf8, std::error_code &ec)
+bool FileStore::writeText(const std::string &rel, const std::string &utf8, std::error_code &ec)
 {
 	ec.clear();
 
 	// パス解決
 	std::string full;
-	if (!resolve_path(rel, full, ec))
+	if (!resolvePath(rel, full, ec))
 		return false;
 
 	// 既に存在する場合は何もしない
 	stdfs::path p(full);
-	if (!create_dirs(p.parent_path().string(), ec))
+	if (!createDirs(p.parent_path().string(), ec))
 		return false;
 
 	// ファイルを開く（存在しない場合は新規作成）
@@ -70,13 +70,13 @@ bool FileStore::write_text(const std::string &rel, const std::string &utf8, std:
 	return true;
 }
 
-bool FileStore::read_text(const std::string &rel, std::string &out, std::error_code &ec) const
+bool FileStore::readText(const std::string &rel, std::string &out, std::error_code &ec) const
 {
 	ec.clear();
 
 	// パス解決
 	std::string full;
-	if (!resolve_path(rel, full, ec))
+	if (!resolvePath(rel, full, ec))
 		return false;
 
 	// ファイルを開く
@@ -111,7 +111,7 @@ bool FileStore::exists(const std::string &rel, std::error_code &ec) const
 	ec.clear();
 
 	std::string full;
-	if (!resolve_path(rel, full, ec))
+	if (!resolvePath(rel, full, ec))
 		return false;
 
 	return stdfs::exists(full, ec);

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -6,69 +6,113 @@
 namespace stdfs = std::filesystem;
 namespace foxclip::infra_shared::fs {
 
-bool FileStore::ensure_dir(const std::string &relDir, std::error_code &ec)
+bool FileStore::resolve_path(const std::string &rel, std::string &full, std::error_code &ec) const
 {
 	bool ok = false;
-	std::string full = resolver_.to_full(relDir, &ok);
+	full = resolver_.to_full(rel, &ok);
 	if (!ok) {
 		ec = std::make_error_code(std::errc::invalid_argument);
 		return false;
 	}
+	return true;
+}
+
+bool FileStore::ensure_dir(const std::string &relDir, std::error_code &ec)
+{
+	ec.clear();
+
+	// パス解決
+	std::string full;
+	if (!resolve_path(relDir, full, ec))
+		return false;
+
+	// 既に存在するか確認
 	return create_dirs(full, ec);
 }
 
 bool FileStore::write_text(const std::string &rel, const std::string &utf8, std::error_code &ec)
 {
-	bool ok = false;
-	std::string full = resolver_.to_full(rel, &ok);
-	if (!ok) {
-		ec = std::make_error_code(std::errc::invalid_argument);
-		return false;
-	}
-
-	// 親を作成
 	ec.clear();
+
+	// パス解決
+	std::string full;
+	if (!resolve_path(rel, full, ec))
+		return false;
+
+	// 既に存在する場合は何もしない
 	stdfs::path p(full);
 	if (!create_dirs(p.parent_path().string(), ec))
 		return false;
 
+	// ファイルを開く（存在しない場合は新規作成）
 	std::ofstream ofs(full, std::ios::binary | std::ios::trunc);
 	if (!ofs) {
-		ec = std::make_error_code(std::errc::permission_denied);
+		// オープンに失敗（権限以外の可能性もあるので io_error の方が無難）
+		ec = std::make_error_code(std::errc::io_error);
 		return false;
 	}
+
+	// 書き込み
 	ofs.write(utf8.data(), static_cast<std::streamsize>(utf8.size()));
-	return ofs.good();
+	if (!ofs.good()) {
+		// 書き込み途中のエラー（ディスクフルなど）
+		ec = std::make_error_code(std::errc::io_error);
+		return false;
+	}
+	// 明示的にフラッシュ
+	// (std::ofstream は自動でフラッシュしないので、書き込み後に明示的に呼ぶ)
+	ofs.flush();
+	if (!ofs.good()) {
+		ec = std::make_error_code(std::errc::io_error);
+		return false;
+	}
+	return true;
 }
 
 bool FileStore::read_text(const std::string &rel, std::string &out, std::error_code &ec) const
 {
-	bool ok = false;
-	std::string full = resolver_.to_full(rel, &ok);
-	if (!ok) {
-		ec = std::make_error_code(std::errc::invalid_argument);
-		return false;
-	}
-
 	ec.clear();
+
+	// パス解決
+	std::string full;
+	if (!resolve_path(rel, full, ec))
+		return false;
+
+	// ファイルを開く
 	std::ifstream ifs(full, std::ios::binary);
 	if (!ifs) {
+		// ファイルが存在しない、または開けない
 		ec = std::make_error_code(std::errc::no_such_file_or_directory);
 		return false;
 	}
+
+	// ファイルサイズを取得（読み込みのための予約）
+	// ここではファイルが空でないことを確認するために、サイズを取得
+	std::error_code fec;
+	auto sz = stdfs::file_size(full, fec);
+	if (!fec && sz > 0)
+		out.reserve(static_cast<size_t>(sz));
+
+	// ファイルの内容を読み込む
 	out.assign((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+	// 読み込みに失敗した場合はエラーコードを設定
+	// eof() は正常な終了なので、good() でチェック
+	if (!ifs.good() && !ifs.eof()) {
+		ec = std::make_error_code(std::errc::io_error);
+		return false;
+	}
+
 	return true;
 }
 
 bool FileStore::exists(const std::string &rel, std::error_code &ec) const
 {
-	bool ok = false;
-	std::string full = resolver_.to_full(rel, &ok);
-	if (!ok) {
-		ec = std::make_error_code(std::errc::invalid_argument);
+	ec.clear();
+
+	std::string full;
+	if (!resolve_path(rel, full, ec))
 		return false;
-	}
-	return std::filesystem::exists(full, ec);
+	return stdfs::exists(full, ec);
 }
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -8,13 +8,14 @@ namespace foxclip::infra_shared::fs {
 
 bool FileStore::resolve_path(const std::string &rel, std::string &full, std::error_code &ec) const
 {
-	bool ok = false;
-	full = resolver_.to_full(rel, &ok);
-	if (!ok) {
-		ec = std::make_error_code(std::errc::invalid_argument);
-		return false;
+	ec.clear();
+	// 相対パスを OBS ルートと結合してフルパスを取得
+	if (auto fullOpt = resolver_.to_full(rel)) {
+		full = *fullOpt;
+		return true;
 	}
-	return true;
+	ec = std::make_error_code(std::errc::invalid_argument);
+	return false;
 }
 
 bool FileStore::ensure_dir(const std::string &relDir, std::error_code &ec)
@@ -112,6 +113,7 @@ bool FileStore::exists(const std::string &rel, std::error_code &ec) const
 	std::string full;
 	if (!resolve_path(rel, full, ec))
 		return false;
+
 	return stdfs::exists(full, ec);
 }
 

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -1,0 +1,74 @@
+#include "FileStore.h"
+#include "FsUtils.h"
+#include <filesystem>
+#include <fstream>
+
+namespace stdfs = std::filesystem;
+namespace foxclip::infra_shared::fs {
+
+bool FileStore::ensure_dir(const std::string &relDir, std::error_code &ec)
+{
+	bool ok = false;
+	std::string full = resolver_.to_full(relDir, &ok);
+	if (!ok) {
+		ec = std::make_error_code(std::errc::invalid_argument);
+		return false;
+	}
+	return create_dirs(full, ec);
+}
+
+bool FileStore::write_text(const std::string &rel, const std::string &utf8, std::error_code &ec)
+{
+	bool ok = false;
+	std::string full = resolver_.to_full(rel, &ok);
+	if (!ok) {
+		ec = std::make_error_code(std::errc::invalid_argument);
+		return false;
+	}
+
+	// 親を作成
+	ec.clear();
+	stdfs::path p(full);
+	if (!create_dirs(p.parent_path().string(), ec))
+		return false;
+
+	std::ofstream ofs(full, std::ios::binary | std::ios::trunc);
+	if (!ofs) {
+		ec = std::make_error_code(std::errc::permission_denied);
+		return false;
+	}
+	ofs.write(utf8.data(), static_cast<std::streamsize>(utf8.size()));
+	return ofs.good();
+}
+
+bool FileStore::read_text(const std::string &rel, std::string &out, std::error_code &ec) const
+{
+	bool ok = false;
+	std::string full = resolver_.to_full(rel, &ok);
+	if (!ok) {
+		ec = std::make_error_code(std::errc::invalid_argument);
+		return false;
+	}
+
+	ec.clear();
+	std::ifstream ifs(full, std::ios::binary);
+	if (!ifs) {
+		ec = std::make_error_code(std::errc::no_such_file_or_directory);
+		return false;
+	}
+	out.assign((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+	return true;
+}
+
+bool FileStore::exists(const std::string &rel, std::error_code &ec) const
+{
+	bool ok = false;
+	std::string full = resolver_.to_full(rel, &ok);
+	if (!ok) {
+		ec = std::make_error_code(std::errc::invalid_argument);
+		return false;
+	}
+	return exists_dir(full, ec) || std::filesystem::exists(full, ec);
+}
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FileStore.h
+++ b/src/infra_shared/fs/FileStore.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <string>
-#include <vector>
 #include <system_error>
 #include "PathResolver.h"
 

--- a/src/infra_shared/fs/FileStore.h
+++ b/src/infra_shared/fs/FileStore.h
@@ -16,6 +16,7 @@ public:
 	bool exists(const std::string &rel, std::error_code &ec) const;
 
 private:
+	bool resolve_path(const std::string& rel, std::string& full, std::error_code& ec) const;
 	PathResolver &resolver_;
 };
 

--- a/src/infra_shared/fs/FileStore.h
+++ b/src/infra_shared/fs/FileStore.h
@@ -7,17 +7,17 @@ namespace foxclip::infra_shared::fs {
 
 class FileStore {
 public:
-	explicit FileStore(PathResolver &resolver) : resolver_(resolver) {}
+	explicit FileStore(PathResolver &resolver) : resolver(resolver) {}
 
 	// 相対パスで OK。内部で OBS ルートに解決し、必要なら親ディレクトリ作成。
-	bool write_text(const std::string &rel, const std::string &utf8, std::error_code &ec);
-	bool read_text(const std::string &rel, std::string &out, std::error_code &ec) const;
-	bool ensure_dir(const std::string &relDir, std::error_code &ec);
+	bool writeText(const std::string &rel, const std::string &utf8, std::error_code &ec);
+	bool readText(const std::string &rel, std::string &out, std::error_code &ec) const;
+	bool ensureDir(const std::string &relDir, std::error_code &ec);
 	bool exists(const std::string &rel, std::error_code &ec) const;
 
 private:
-	bool resolve_path(const std::string &rel, std::string &full, std::error_code &ec) const;
-	PathResolver &resolver_;
+	bool resolvePath(const std::string &rel, std::string &full, std::error_code &ec) const;
+	PathResolver &resolver;
 };
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FileStore.h
+++ b/src/infra_shared/fs/FileStore.h
@@ -16,7 +16,7 @@ public:
 	bool exists(const std::string &rel, std::error_code &ec) const;
 
 private:
-	bool resolve_path(const std::string& rel, std::string& full, std::error_code& ec) const;
+	bool resolve_path(const std::string &rel, std::string &full, std::error_code &ec) const;
 	PathResolver &resolver_;
 };
 

--- a/src/infra_shared/fs/FileStore.h
+++ b/src/infra_shared/fs/FileStore.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <system_error>
+#include "PathResolver.h"
+
+namespace foxclip::infra_shared::fs {
+
+class FileStore {
+public:
+	explicit FileStore(PathResolver &resolver) : resolver_(resolver) {}
+
+	// 相対パスで OK。内部で OBS ルートに解決し、必要なら親ディレクトリ作成。
+	bool write_text(const std::string &rel, const std::string &utf8, std::error_code &ec);
+	bool read_text(const std::string &rel, std::string &out, std::error_code &ec) const;
+	bool ensure_dir(const std::string &relDir, std::error_code &ec);
+	bool exists(const std::string &rel, std::error_code &ec) const;
+
+private:
+	PathResolver &resolver_;
+};
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FsUtils.cpp
+++ b/src/infra_shared/fs/FsUtils.cpp
@@ -1,33 +1,39 @@
 #include "FsUtils.h"
 #include <filesystem>
 
-namespace stdfs = std::filesystem;  
+namespace stdfs = std::filesystem;
 
 namespace foxclip::infra_shared::fs {
 
-bool exists_dir(const std::string& pathStr, std::error_code& ec) noexcept {
-  ec.clear();
-  // exists と is_directory を std::filesystem 側に明示
-  return stdfs::exists(pathStr, ec) && stdfs::is_directory(pathStr, ec);
+bool exists_dir(const std::string &pathStr, std::error_code &ec) noexcept
+{
+	ec.clear();
+	// exists と is_directory を std::filesystem 側に明示
+	return stdfs::exists(pathStr, ec) && stdfs::is_directory(pathStr, ec);
 }
 
-bool create_dirs(const std::string& pathStr, std::error_code& ec) noexcept {
-  ec.clear();
-  if (exists_dir(pathStr, ec)) return !ec;
-  const bool ok = stdfs::create_directories(pathStr, ec);
-  if (ec) return false;
-  // 既存でも成功扱い
-  return ok || exists_dir(pathStr, ec);
+bool create_dirs(const std::string &pathStr, std::error_code &ec) noexcept
+{
+	ec.clear();
+	if (exists_dir(pathStr, ec))
+		return !ec;
+	const bool ok = stdfs::create_directories(pathStr, ec);
+	if (ec)
+		return false;
+	// 既存でも成功扱い
+	return ok || exists_dir(pathStr, ec);
 }
 
-std::string join(const std::string& base, const std::string& name) {
-  return (stdfs::path(base) / stdfs::path(name)).string();
+std::string join(const std::string &base, const std::string &name)
+{
+	return (stdfs::path(base) / stdfs::path(name)).string();
 }
 
-bool is_abs(const std::string& pathStr) noexcept {
-  std::error_code ec;
-  (void)ec;
-  return stdfs::path(pathStr).is_absolute();
+bool is_abs(const std::string &pathStr) noexcept
+{
+	std::error_code ec;
+	(void)ec;
+	return stdfs::path(pathStr).is_absolute();
 }
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FsUtils.cpp
+++ b/src/infra_shared/fs/FsUtils.cpp
@@ -1,0 +1,33 @@
+#include "FsUtils.h"
+#include <filesystem>
+
+namespace stdfs = std::filesystem;  
+
+namespace foxclip::infra_shared::fs {
+
+bool exists_dir(const std::string& pathStr, std::error_code& ec) noexcept {
+  ec.clear();
+  // exists と is_directory を std::filesystem 側に明示
+  return stdfs::exists(pathStr, ec) && stdfs::is_directory(pathStr, ec);
+}
+
+bool create_dirs(const std::string& pathStr, std::error_code& ec) noexcept {
+  ec.clear();
+  if (exists_dir(pathStr, ec)) return !ec;
+  const bool ok = stdfs::create_directories(pathStr, ec);
+  if (ec) return false;
+  // 既存でも成功扱い
+  return ok || exists_dir(pathStr, ec);
+}
+
+std::string join(const std::string& base, const std::string& name) {
+  return (stdfs::path(base) / stdfs::path(name)).string();
+}
+
+bool is_abs(const std::string& pathStr) noexcept {
+  std::error_code ec;
+  (void)ec;
+  return stdfs::path(pathStr).is_absolute();
+}
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FsUtils.cpp
+++ b/src/infra_shared/fs/FsUtils.cpp
@@ -5,23 +5,23 @@ namespace stdfs = std::filesystem;
 
 namespace foxclip::infra_shared::fs {
 
-bool exists_dir(const std::string &pathStr, std::error_code &ec) noexcept
+bool existsDir(const std::string &pathStr, std::error_code &ec) noexcept
 {
 	ec.clear();
 	// exists と is_directory を std::filesystem 側に明示
 	return stdfs::exists(pathStr, ec) && stdfs::is_directory(pathStr, ec);
 }
 
-bool create_dirs(const std::string &pathStr, std::error_code &ec) noexcept
+bool createDirs(const std::string &pathStr, std::error_code &ec) noexcept
 {
 	ec.clear();
-	if (exists_dir(pathStr, ec))
+	if (existsDir(pathStr, ec))
 		return !ec;
 	const bool ok = stdfs::create_directories(pathStr, ec);
 	if (ec)
 		return false;
 	// 既存でも成功扱い
-	return ok || exists_dir(pathStr, ec);
+	return ok || existsDir(pathStr, ec);
 }
 
 std::string join(const std::string &base, const std::string &name)
@@ -29,7 +29,7 @@ std::string join(const std::string &base, const std::string &name)
 	return (stdfs::path(base) / stdfs::path(name)).string();
 }
 
-bool is_abs(const std::string &pathStr) noexcept
+bool isAbs(const std::string &pathStr) noexcept
 {
 	return stdfs::path(pathStr).is_absolute();
 }

--- a/src/infra_shared/fs/FsUtils.cpp
+++ b/src/infra_shared/fs/FsUtils.cpp
@@ -31,8 +31,6 @@ std::string join(const std::string &base, const std::string &name)
 
 bool is_abs(const std::string &pathStr) noexcept
 {
-	std::error_code ec;
-	(void)ec;
 	return stdfs::path(pathStr).is_absolute();
 }
 

--- a/src/infra_shared/fs/FsUtils.h
+++ b/src/infra_shared/fs/FsUtils.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+#include <system_error>
+
+namespace foxclip::infra_shared::fs {
+
+bool exists_dir(const std::string& path, std::error_code& ec) noexcept;
+bool create_dirs(const std::string& path, std::error_code& ec) noexcept;
+std::string join(const std::string& base, const std::string& name);
+bool is_abs(const std::string& path) noexcept;
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FsUtils.h
+++ b/src/infra_shared/fs/FsUtils.h
@@ -4,9 +4,9 @@
 
 namespace foxclip::infra_shared::fs {
 
-bool exists_dir(const std::string& path, std::error_code& ec) noexcept;
-bool create_dirs(const std::string& path, std::error_code& ec) noexcept;
-std::string join(const std::string& base, const std::string& name);
-bool is_abs(const std::string& path) noexcept;
+bool exists_dir(const std::string &path, std::error_code &ec) noexcept;
+bool create_dirs(const std::string &path, std::error_code &ec) noexcept;
+std::string join(const std::string &base, const std::string &name);
+bool is_abs(const std::string &path) noexcept;
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FsUtils.h
+++ b/src/infra_shared/fs/FsUtils.h
@@ -4,9 +4,9 @@
 
 namespace foxclip::infra_shared::fs {
 
-bool exists_dir(const std::string &path, std::error_code &ec) noexcept;
-bool create_dirs(const std::string &path, std::error_code &ec) noexcept;
+bool existsDir(const std::string &path, std::error_code &ec) noexcept;
+bool createDirs(const std::string &path, std::error_code &ec) noexcept;
 std::string join(const std::string &base, const std::string &name);
-bool is_abs(const std::string &path) noexcept;
+bool isAbs(const std::string &path) noexcept;
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/PathResolver.cpp
+++ b/src/infra_shared/fs/PathResolver.cpp
@@ -6,7 +6,7 @@
 namespace stdfs = std::filesystem;
 namespace foxclip::infra_shared::fs {
 
-static bool contains_parent_ref(const std::string &rel)
+static bool containsParentRef(const std::string &rel)
 {
 	auto p = stdfs::path(rel);
 	for (const auto &part : p) {
@@ -16,15 +16,15 @@ static bool contains_parent_ref(const std::string &rel)
 	return false;
 }
 
-std::optional<std::string> PathResolver::to_full(const std::string &relative) const
+std::optional<std::string> PathResolver::toFull(const std::string &relative) const
 {
 	// 入力検証：空、絶対、親ディレクトリ参照は拒否
-	if (relative.empty() || is_abs(relative) || contains_parent_ref(relative)) {
+	if (relative.empty() || isAbs(relative) || containsParentRef(relative)) {
 		return std::nullopt;
 	}
 
 	// ルート取得
-	const std::string base = root_.root();
+	const std::string base = root.root();
 	if (base.empty()) {
 		return std::nullopt;
 	}

--- a/src/infra_shared/fs/PathResolver.cpp
+++ b/src/infra_shared/fs/PathResolver.cpp
@@ -17,25 +17,18 @@ static bool contains_parent_ref(const std::string &rel)
 
 std::string PathResolver::to_full(const std::string &relative, bool *ok) const
 {
-	bool good = true;
-	if (relative.empty())
-		good = false;
-	if (is_abs(relative))
-		good = false;
-	if (contains_parent_ref(relative))
-		good = false;
-
-	std::string base = root_.root();
-	if (base.empty())
-		good = false;
-
-	if (!good) {
-		if (ok)
-			*ok = false;
+	if (relative.empty() || is_abs(relative) || contains_parent_ref(relative)) {
+		if (ok) *ok = false;
 		return {};
 	}
-	if (ok)
-		*ok = true;
+
+	std::string base = root_.root();
+	if (base.empty()) {
+		if (ok) *ok = false;
+		return {};
+	}
+
+	if (ok) *ok = true;
 	return (stdfs::path(base) / stdfs::path(relative)).lexically_normal().string();
 }
 

--- a/src/infra_shared/fs/PathResolver.cpp
+++ b/src/infra_shared/fs/PathResolver.cpp
@@ -1,0 +1,42 @@
+#include "PathResolver.h"
+#include "FsUtils.h"
+#include <filesystem>
+
+namespace stdfs = std::filesystem;
+namespace foxclip::infra_shared::fs {
+
+static bool contains_parent_ref(const std::string &rel)
+{
+	auto p = stdfs::path(rel);
+	for (auto &part : p) {
+		if (part == "..")
+			return true;
+	}
+	return false;
+}
+
+std::string PathResolver::to_full(const std::string &relative, bool *ok) const
+{
+	bool good = true;
+	if (relative.empty())
+		good = false;
+	if (is_abs(relative))
+		good = false;
+	if (contains_parent_ref(relative))
+		good = false;
+
+	std::string base = root_.root();
+	if (base.empty())
+		good = false;
+
+	if (!good) {
+		if (ok)
+			*ok = false;
+		return {};
+	}
+	if (ok)
+		*ok = true;
+	return (stdfs::path(base) / stdfs::path(relative)).lexically_normal().string();
+}
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/PathResolver.cpp
+++ b/src/infra_shared/fs/PathResolver.cpp
@@ -18,17 +18,20 @@ static bool contains_parent_ref(const std::string &rel)
 std::string PathResolver::to_full(const std::string &relative, bool *ok) const
 {
 	if (relative.empty() || is_abs(relative) || contains_parent_ref(relative)) {
-		if (ok) *ok = false;
+		if (ok)
+			*ok = false;
 		return {};
 	}
 
 	std::string base = root_.root();
 	if (base.empty()) {
-		if (ok) *ok = false;
+		if (ok)
+			*ok = false;
 		return {};
 	}
 
-	if (ok) *ok = true;
+	if (ok)
+		*ok = true;
 	return (stdfs::path(base) / stdfs::path(relative)).lexically_normal().string();
 }
 

--- a/src/infra_shared/fs/PathResolver.h
+++ b/src/infra_shared/fs/PathResolver.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <string>
+#include "infra_shared/fs/roots/IRootProvider.h"
+
+namespace foxclip::infra_shared::fs {
+
+class PathResolver {
+public:
+	explicit PathResolver(roots::IRootProvider &root) : root_(root) {}
+	// 相対パスのみ受け付け、root() と結合したフルパスを返す。絶対や ".." は拒否/正規化。
+	std::string to_full(const std::string &relative, bool *ok = nullptr) const;
+
+private:
+	roots::IRootProvider &root_;
+};
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/PathResolver.h
+++ b/src/infra_shared/fs/PathResolver.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <optional>
 #include "infra_shared/fs/roots/IRootProvider.h"
 
 namespace foxclip::infra_shared::fs {
@@ -8,7 +9,7 @@ class PathResolver {
 public:
 	explicit PathResolver(roots::IRootProvider &root) : root_(root) {}
 	// 相対パスのみ受け付け、root() と結合したフルパスを返す。絶対や ".." は拒否/正規化。
-	std::string to_full(const std::string &relative, bool *ok = nullptr) const;
+	std::optional<std::string> to_full(const std::string &relative) const;
 
 private:
 	roots::IRootProvider &root_;

--- a/src/infra_shared/fs/PathResolver.h
+++ b/src/infra_shared/fs/PathResolver.h
@@ -7,12 +7,12 @@ namespace foxclip::infra_shared::fs {
 
 class PathResolver {
 public:
-	explicit PathResolver(roots::IRootProvider &root) : root_(root) {}
+	explicit PathResolver(roots::IRootProvider &root) : root(root) {}
 	// 相対パスのみ受け付け、root() と結合したフルパスを返す。絶対や ".." は拒否/正規化。
-	std::optional<std::string> to_full(const std::string &relative) const;
+	std::optional<std::string> toFull(const std::string &relative) const;
 
 private:
-	roots::IRootProvider &root_;
+	roots::IRootProvider &root;
 };
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/roots/IRootProvider.h
+++ b/src/infra_shared/fs/roots/IRootProvider.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+
+namespace foxclip::infra_shared::fs::roots {
+
+class IRootProvider {
+public:
+	virtual ~IRootProvider() = default;
+	// 末尾セパレータ無しの絶対パス（UTF-8）を返す。失敗時は空文字。
+	virtual std::string root() = 0;
+};
+
+} // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
@@ -1,14 +1,23 @@
+// ObsConfigRootProvider.cpp
 #include "ObsConfigRootProvider.h"
 #include "infra_shared/config/path/ObsConfigPathProvider.h"
 
 namespace foxclip::infra_shared::fs::roots {
 
+using foxclip::infra_shared::config::path::makeObsConfigPathProvider;
+using foxclip::infra_shared::config::path::IConfigPathProvider;
+
+ObsConfigRootProvider::ObsConfigRootProvider(std::shared_ptr<IConfigPathProvider> provider)
+    : provider_(std::move(provider))
+{
+    if (!provider_) {
+        provider_ = makeObsConfigPathProvider(); // コンストラクタで1回だけ生成
+    }
+}
+
 std::string ObsConfigRootProvider::root()
 {
-	using foxclip::infra_shared::config::path::makeObsConfigPathProvider;
-	auto prov = makeObsConfigPathProvider();
-	// ""（または nullptr 相当）で「このプラグインのルート」ディレクトリ
-	return prov->config_path(""); // 例: .../obs-studio/plugin_config/<plugin>
+    return provider_->config_path("");
 }
 
 } // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
@@ -8,16 +8,16 @@ using foxclip::infra_shared::config::path::makeObsConfigPathProvider;
 using foxclip::infra_shared::config::path::IConfigPathProvider;
 
 ObsConfigRootProvider::ObsConfigRootProvider(std::shared_ptr<IConfigPathProvider> provider)
-    : provider_(std::move(provider))
+	: provider_(std::move(provider))
 {
-    if (!provider_) {
-        provider_ = makeObsConfigPathProvider(); // コンストラクタで1回だけ生成
-    }
+	if (!provider_) {
+		provider_ = makeObsConfigPathProvider(); // コンストラクタで1回だけ生成
+	}
 }
 
 std::string ObsConfigRootProvider::root()
 {
-    return provider_->config_path("");
+	return provider_->config_path("");
 }
 
 } // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
@@ -1,4 +1,3 @@
-// ObsConfigRootProvider.cpp
 #include "ObsConfigRootProvider.h"
 #include "infra_shared/config/path/ObsConfigPathProvider.h"
 
@@ -7,17 +6,27 @@ namespace foxclip::infra_shared::fs::roots {
 using foxclip::infra_shared::config::path::makeObsConfigPathProvider;
 using foxclip::infra_shared::config::path::IConfigPathProvider;
 
+
 ObsConfigRootProvider::ObsConfigRootProvider(std::shared_ptr<IConfigPathProvider> provider)
-	: provider_(std::move(provider))
+    : pathProvider(provider ? std::move(provider) : makeObsConfigPathProvider())
 {
-	if (!provider_) {
-		provider_ = makeObsConfigPathProvider(); // コンストラクタで1回だけ生成
-	}
+    // 本体
 }
 
 std::string ObsConfigRootProvider::root()
 {
-	return provider_->config_path("");
+	// 遅延初期化（保険）。工場が null を返す可能性にも対応
+	if (!pathProvider) {
+		auto created = makeObsConfigPathProvider();
+		if (!created) {
+			// ここでは決して参照しない。空文字を返して上位で失敗扱いにする。
+			return {};
+		}
+		pathProvider = std::move(created);
+	}
+
+	// ここまで来たら必ず非 null
+	return pathProvider->configPath("");
 }
 
 } // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
@@ -6,11 +6,10 @@ namespace foxclip::infra_shared::fs::roots {
 using foxclip::infra_shared::config::path::makeObsConfigPathProvider;
 using foxclip::infra_shared::config::path::IConfigPathProvider;
 
-
 ObsConfigRootProvider::ObsConfigRootProvider(std::shared_ptr<IConfigPathProvider> provider)
-    : pathProvider(provider ? std::move(provider) : makeObsConfigPathProvider())
+	: pathProvider(provider ? std::move(provider) : makeObsConfigPathProvider())
 {
-    // 本体
+	// 本体
 }
 
 std::string ObsConfigRootProvider::root()

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
@@ -1,0 +1,14 @@
+#include "ObsConfigRootProvider.h"
+#include "infra_shared/config/path/ObsConfigPathProvider.h"
+
+namespace foxclip::infra_shared::fs::roots {
+
+std::string ObsConfigRootProvider::root()
+{
+	using foxclip::infra_shared::config::path::MakeObsConfigPathProvider;
+	auto prov = MakeObsConfigPathProvider();
+	// ""（または nullptr 相当）で「このプラグインのルート」ディレクトリ
+	return prov->config_path(""); // 例: .../obs-studio/plugin_config/<plugin>
+}
+
+} // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
@@ -5,8 +5,8 @@ namespace foxclip::infra_shared::fs::roots {
 
 std::string ObsConfigRootProvider::root()
 {
-	using foxclip::infra_shared::config::path::MakeObsConfigPathProvider;
-	auto prov = MakeObsConfigPathProvider();
+	using foxclip::infra_shared::config::path::makeObsConfigPathProvider;
+	auto prov = makeObsConfigPathProvider();
 	// ""（または nullptr 相当）で「このプラグインのルート」ディレクトリ
 	return prov->config_path(""); // 例: .../obs-studio/plugin_config/<plugin>
 }

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.h
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.h
@@ -18,7 +18,7 @@ public:
 	std::string root() override;
 
 private:
-	std::shared_ptr<Provider> provider_;
+	std::shared_ptr<Provider> pathProvider;
 };
 
 } // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.h
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "IRootProvider.h"
+
+namespace foxclip::infra_shared::fs::roots {
+
+class ObsConfigRootProvider final : public IRootProvider {
+public:
+	std::string root() override; // 実装は .cpp
+};
+
+} // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.h
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.h
@@ -1,11 +1,24 @@
 #pragma once
+#include <memory>
 #include "IRootProvider.h"
+
+namespace foxclip::infra_shared::config::path {
+class IConfigPathProvider;
+}
 
 namespace foxclip::infra_shared::fs::roots {
 
 class ObsConfigRootProvider final : public IRootProvider {
 public:
-	std::string root() override; // 実装は .cpp
+	using Provider = foxclip::infra_shared::config::path::IConfigPathProvider;
+
+	// 既定は nullptr。nullptr の場合は .cpp 側でファクトリから生成
+	explicit ObsConfigRootProvider(std::shared_ptr<Provider> provider = nullptr);
+
+	std::string root() override;
+
+private:
+	std::shared_ptr<Provider> provider_;
 };
 
 } // namespace foxclip::infra_shared::fs::roots

--- a/src/infra_shared/startup/EnsurePluginDir.cpp
+++ b/src/infra_shared/startup/EnsurePluginDir.cpp
@@ -5,11 +5,11 @@
 
 namespace foxclip::infra_shared::startup {
 
-EnsureResult ensure_obs_writable_dir(const std::string &subdir)
+EnsureResult ensureObsWritableDir(const std::string &subdir)
 {
 	using foxclip::infra_shared::fs::roots::ObsConfigRootProvider;
 	using foxclip::infra_shared::fs::PathResolver;
-	using foxclip::infra_shared::fs::create_dirs;
+	using foxclip::infra_shared::fs::createDirs;
 
 	// 1) OBS ルート取得（…/plugin_config/<plugin>）
 	ObsConfigRootProvider root;
@@ -19,14 +19,14 @@ EnsureResult ensure_obs_writable_dir(const std::string &subdir)
 
 	// 2) 相対 subdir をルート配下のフルパスへ正規化
 	PathResolver resolver(root);
-	const auto fullOpt = resolver.to_full(subdir);
+	const auto fullOpt = resolver.toFull(subdir);
 	if (!fullOpt || fullOpt->empty())
 		return {false, {}, "invalid subdir (absolute or contains ..)"};
 
 	const std::string &full = *fullOpt;
 
 	std::error_code ec;
-	if (!create_dirs(full, ec)) {
+	if (!createDirs(full, ec)) {
 		std::string msg = "failed to create '" + subdir + "'";
 		if (ec)
 			msg += ": " + ec.message();

--- a/src/infra_shared/startup/EnsurePluginDir.cpp
+++ b/src/infra_shared/startup/EnsurePluginDir.cpp
@@ -1,0 +1,38 @@
+#include "EnsurePluginDir.h"
+#include "infra_shared/fs/roots/ObsConfigRootProvider.h"
+#include "infra_shared/fs/PathResolver.h"
+#include "infra_shared/fs/FsUtils.h"
+
+namespace foxclip::infra_shared::startup {
+
+EnsureResult ensure_obs_writable_dir(const std::string &subdir)
+{
+	using foxclip::infra_shared::fs::roots::ObsConfigRootProvider;
+	using foxclip::infra_shared::fs::PathResolver;
+	using foxclip::infra_shared::fs::create_dirs;
+
+	// 1) OBS ルート取得（…/plugin_config/<plugin>）
+	ObsConfigRootProvider root;
+	const std::string base = root.root();
+	if (base.empty())
+		return {false, {}, "failed to resolve OBS config root"};
+
+	// 2) 相対 subdir をルート配下のフルパスへ正規化
+	PathResolver resolver(root);
+	bool ok = false;
+	const std::string full = resolver.to_full(subdir, &ok);
+	if (!ok || full.empty())
+		return {false, {}, "invalid subdir (absolute or contains ..)"};
+
+	std::error_code ec;
+	if (!create_dirs(full, ec)) {
+		std::string msg = "failed to create '" + subdir + "'";
+		if (ec)
+			msg += ": " + ec.message();
+		return {false, {}, msg};
+	}
+
+	return {true, full, {}};
+}
+
+} // namespace foxclip::infra_shared::startup

--- a/src/infra_shared/startup/EnsurePluginDir.cpp
+++ b/src/infra_shared/startup/EnsurePluginDir.cpp
@@ -19,10 +19,11 @@ EnsureResult ensure_obs_writable_dir(const std::string &subdir)
 
 	// 2) 相対 subdir をルート配下のフルパスへ正規化
 	PathResolver resolver(root);
-	bool ok = false;
-	const std::string full = resolver.to_full(subdir, &ok);
-	if (!ok || full.empty())
+	const auto fullOpt = resolver.to_full(subdir);
+	if (!fullOpt || fullOpt->empty())
 		return {false, {}, "invalid subdir (absolute or contains ..)"};
+
+	const std::string &full = *fullOpt;
 
 	std::error_code ec;
 	if (!create_dirs(full, ec)) {

--- a/src/infra_shared/startup/EnsurePluginDir.h
+++ b/src/infra_shared/startup/EnsurePluginDir.h
@@ -10,6 +10,6 @@ struct EnsureResult {
 	std::string errorMessage;
 };
 
-EnsureResult ensure_obs_writable_dir(const std::string &subdir);
+EnsureResult ensureObsWritableDir(const std::string &subdir);
 
 } // namespace foxclip::infra_shared::startup

--- a/src/infra_shared/startup/EnsurePluginDir.h
+++ b/src/infra_shared/startup/EnsurePluginDir.h
@@ -1,14 +1,13 @@
 #pragma once
 #include <string>
-#include <system_error>
 
 namespace foxclip::infra_shared::startup {
 
-// 成功時: full_path を返す / 失敗時: 空文字と error_message を返す
+// 成功時: fullPath を返す / 失敗時: 空文字と errorMessage を返す
 struct EnsureResult {
 	bool ok{};
-	std::string full_path;
-	std::string error_message;
+	std::string fullPath;
+	std::string errorMessage;
 };
 
 EnsureResult ensure_obs_writable_dir(const std::string &subdir);

--- a/src/infra_shared/startup/EnsurePluginDir.h
+++ b/src/infra_shared/startup/EnsurePluginDir.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <string>
+#include <system_error>
+
+namespace foxclip::infra_shared::startup {
+
+// 成功時: full_path を返す / 失敗時: 空文字と error_message を返す
+struct EnsureResult {
+  bool ok{};
+  std::string full_path;
+  std::string error_message;
+};
+
+EnsureResult ensure_obs_writable_dir(const std::string& subdir);
+
+} // namespace foxclip::infra_shared::startup

--- a/src/infra_shared/startup/EnsurePluginDir.h
+++ b/src/infra_shared/startup/EnsurePluginDir.h
@@ -6,11 +6,11 @@ namespace foxclip::infra_shared::startup {
 
 // 成功時: full_path を返す / 失敗時: 空文字と error_message を返す
 struct EnsureResult {
-  bool ok{};
-  std::string full_path;
-  std::string error_message;
+	bool ok{};
+	std::string full_path;
+	std::string error_message;
 };
 
-EnsureResult ensure_obs_writable_dir(const std::string& subdir);
+EnsureResult ensure_obs_writable_dir(const std::string &subdir);
 
 } // namespace foxclip::infra_shared::startup


### PR DESCRIPTION
- #39 
## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
* **anyは使わない**

  * 対象は **`std::any` 禁止** の意味、と明記してください。
  * 代替: 具体型／`std::variant`／テンプレートで表現。レビューは `[必須]`（型安全性）で指摘。

* **命名**

  * 型／クラス名: `UpperCamel`、関数・変数: `lowerCamel` を「ファイル全域で統一」。
  * 定数は `kUpperCamel`（例: `kMaxSize`）を推奨（衝突回避・視認性）。
  * テスト用の fixture, matcher も命名規約の例外にしない（統一が楽）。

* **予約識別子（アンダースコア関連）**

  * 「アンダースコア＋大文字で始まる名前」「連続する二つのアンダースコア」は**予約**なので**全面禁止**。
  * **大域（グローバル）名前空間でアンダースコア始まり**も**禁止**（標準予約）。
  * これらは\*\*`[必須]`違反\*\*として扱い、機械検出を必須化（後述）。

* **std 名前空間**

  * **`namespace std { ... }` での追加・変更は禁止（未定義動作）**。
  * ただし標準が許容する**ユーザー定義型に対する既存テンプレートの**明示的**特殊化**（例: `std::hash<MyType>`、`std::formatter<MyType>`）は可。
  * 可否を規約に明文化（「フル特殊化のみ可・部分特殊化不可」など）。

* **引数は 3～5 個を目安**

  * 6 個以上は**構造体に束ねる** or **Builder** を推奨（レビューは `[推奨]`）。
  * 「可変長引数」「多数の bool 引数」も原則禁止。意味不明瞭なら `[必須]` で差戻し。

* **モジュール化（infra_shared/**）**

  * **複数モジュールから使う可能性のある処理は** `infra_shared/<機能区分>/` に配置。
  * インタフェースは最小依存（PIMPL/前方宣言）＋ **安定 ABI/ヘッダ** を意識。
  * CMake は `infra_shared_*` を**静的ライブラリ**に分離し、**依存の向き**（アプリ→shared）を厳守。

<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->