### PR TITLE
feature/#51

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,14 +56,16 @@ target_sources(
     src/features/startup_check/domain/StartupCheckService.cpp
     src/features/startup_check/infrastructure/StdFsDirectoryChecker.cpp
     src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
+    src/infra_shared/fs/FsUtils.cpp
+    src/infra_shared/fs/FileStore.cpp
+    src/infra_shared/fs/PathResolver.cpp
+    src/infra_shared/fs/DirectoryLister.cpp
+    src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+    src/infra_shared/log/ObsLogger.c
     src/infra_shared/config/path/ObsConfigPathProvider.cpp
     src/infra_shared/plugin/FoxclipPluginHost.cpp
-    src/infra_shared/fs/FsUtils.cpp
-    src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
-    src/infra_shared/fs/PathResolver.cpp
-    src/infra_shared/fs/FileStore.cpp
+    src/infra_shared/plugin/PluginFolderLogger.cpp
     src/infra_shared/startup/EnsurePluginDir.cpp
-    src/infra_shared/log/ObsLogger.c
     src/public_api/log/FoxclipLogApi.c
 )
 

--- a/src/app/plugin-main.cpp
+++ b/src/app/plugin-main.cpp
@@ -3,10 +3,14 @@
 #include <obs-module.h>
 #include <obs-frontend-api.h>
 
+#include "features/startup_check/app/StartupCheckFacade.h"
+#include "infra_shared/fs/DirectoryLister.h"
+#include "infra_shared/fs/roots/ObsConfigRootProvider.h"
+#include "infra_shared/fs/PathResolver.h"
 #include "infra_shared/log/ObsLogger.h"
 #include "infra_shared/config/build/plugin-config.h"
-#include "features/startup_check/app/StartupCheckFacade.h"
 #include "infra_shared/plugin/FoxclipPluginHost.h"
+#include "infra_shared/plugin/PluginFolderLogger.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
@@ -20,8 +24,10 @@ bool obs_module_load(void)
 	using foxclip::startup_check::app::StartupCheckFacade;
 	using foxclip::startup_check::infrastructure::StdFsDirectoryChecker;
 
+	const std::string pluginDirName = "foxclip-plugins";
+
 	auto checker = std::make_unique<StdFsDirectoryChecker>();
-	StartupCheckFacade facade(std::move(checker), "foxclip-plugins");
+	StartupCheckFacade facade(std::move(checker), pluginDirName);
 	auto r = facade.run();
 	if (!r.ok) {
 		// Log error Directory does not exist
@@ -30,6 +36,8 @@ bool obs_module_load(void)
 		// TODO: In the future, add functionality to automatically create the directory if it does not exist
 		//return false;
 	}
+
+	foxclip::infra_shared::plugin::logPluginSubfolders(pluginDirName);
 
 	// Tools メニューにカスタム QAction を追加
 	const char *label = obs_module_text("Tools.Menu.FoxClip");

--- a/src/infra_shared/fs/DirectoryLister.cpp
+++ b/src/infra_shared/fs/DirectoryLister.cpp
@@ -1,7 +1,7 @@
 #include "infra_shared/fs/DirectoryLister.h"
 
-#include <system_error>
 #include <filesystem>
+#include <system_error>
 
 namespace foxclip::infra_shared::fs {
 
@@ -9,21 +9,36 @@ std::vector<std::filesystem::path> DirectoryLister::listSubdirectories(const std
 {
 	std::vector<std::filesystem::path> result;
 
+	// ルート検証（非throw）
 	std::error_code ec;
-	if (!std::filesystem::exists(root, ec) || !std::filesystem::is_directory(root, ec)) {
-		return result; // ルートが無い/ディレクトリでない -> 空返し
+	if (!std::filesystem::is_directory(root, ec)) {
+		return result; // ディレクトリでなければ空返し
 	}
 
-	for (const auto &entry : std::filesystem::directory_iterator(root, ec)) {
-		if (ec) { // 途中でエラーが出たらスキップして継続
+	// パーミッション拒否はスキップ。以降も常に non-throw で回す。
+	const auto opts = std::filesystem::directory_options::skip_permission_denied;
+
+	std::filesystem::directory_iterator it(root, opts, ec), end;
+	if (ec) {
+		// begin 構築時に失敗したら終了
+		return result;
+	}
+
+	for (; it != end; it.increment(ec)) {
+		if (ec) {
+			// increment での一時的な失敗はスキップして続行
 			ec.clear();
 			continue;
 		}
+
+		// エントリがディレクトリかどうか（非throw）
 		std::error_code typeEc;
-		if (entry.is_directory(typeEc) && !typeEc) {
-			result.push_back(entry.path());
+		if (it->is_directory(typeEc) && !typeEc) {
+			result.push_back(it->path());
 		}
+		// typeEc が立っても次へ
 	}
+
 	return result;
 }
 

--- a/src/infra_shared/fs/DirectoryLister.cpp
+++ b/src/infra_shared/fs/DirectoryLister.cpp
@@ -1,0 +1,30 @@
+#include "infra_shared/fs/DirectoryLister.h"
+
+#include <system_error>
+#include <filesystem>
+
+namespace foxclip::infra_shared::fs {
+
+std::vector<std::filesystem::path> DirectoryLister::listSubdirectories(const std::filesystem::path &root)
+{
+	std::vector<std::filesystem::path> result;
+
+	std::error_code ec;
+	if (!std::filesystem::exists(root, ec) || !std::filesystem::is_directory(root, ec)) {
+		return result; // ルートが無い/ディレクトリでない -> 空返し
+	}
+
+	for (const auto &entry : std::filesystem::directory_iterator(root, ec)) {
+		if (ec) { // 途中でエラーが出たらスキップして継続
+			ec.clear();
+			continue;
+		}
+		std::error_code typeEc;
+		if (entry.is_directory(typeEc) && !typeEc) {
+			result.push_back(entry.path());
+		}
+	}
+	return result;
+}
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/DirectoryLister.cpp
+++ b/src/infra_shared/fs/DirectoryLister.cpp
@@ -25,11 +25,8 @@ std::vector<std::filesystem::path> DirectoryLister::listSubdirectories(const std
 	}
 
 	for (; it != end; it.increment(ec)) {
-		if (ec) {
-			// increment での一時的な失敗はスキップして続行
-			ec.clear();
-			continue;
-		}
+		// increment(ec) でエラーが出ると it==end になりループ終了
+		// → 明示的な ec チェック/クリア処理は不要
 
 		// エントリがディレクトリかどうか（非throw）
 		std::error_code typeEc;

--- a/src/infra_shared/fs/DirectoryLister.h
+++ b/src/infra_shared/fs/DirectoryLister.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <filesystem>
+#include <vector>
+
+namespace foxclip::infra_shared::fs {
+
+// ディレクトリ直下のサブディレクトリ（フォルダー）のみを列挙するユーティリティ。
+// 例外は投げず、アクセス不能などは空ベクタを返す。
+class DirectoryLister {
+public:
+	static std::vector<std::filesystem::path> listSubdirectories(const std::filesystem::path &root);
+};
+
+} // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/plugin/PluginFolderLogger.cpp
+++ b/src/infra_shared/plugin/PluginFolderLogger.cpp
@@ -1,0 +1,41 @@
+#include "infra_shared/plugin/PluginFolderLogger.h"
+
+#include <filesystem>
+
+#include "infra_shared/log/ObsLogger.h"
+#include "infra_shared/fs/DirectoryLister.h"
+#include "infra_shared/fs/roots/ObsConfigRootProvider.h"
+#include "infra_shared/fs/PathResolver.h"
+
+namespace foxclip::infra_shared::plugin {
+
+void logPluginSubfolders(const std::string &pluginDirName)
+{
+	using foxclip::infra_shared::fs::roots::ObsConfigRootProvider;
+	using foxclip::infra_shared::fs::PathResolver;
+	using foxclip::infra_shared::fs::DirectoryLister;
+
+	ObsConfigRootProvider root;
+	PathResolver resolver(root);
+	const auto fullOpt = resolver.toFull(pluginDirName);
+
+	if (!fullOpt || fullOpt->empty()) {
+		OBS_LOG_WARN("[foxclip] failed to resolve plugin root for '%s'", pluginDirName.c_str());
+		return;
+	}
+
+	const std::string pluginRoot = *fullOpt;
+	const std::filesystem::path rootPath{pluginRoot};
+	const auto subs = DirectoryLister::listSubdirectories(rootPath);
+
+	OBS_LOG_INFO("[foxclip] Plugin folder listing: %s", pluginRoot.c_str());
+	if (subs.empty()) {
+		OBS_LOG_INFO("[foxclip] (no subfolders found)");
+		return;
+	}
+	for (const auto &p : subs) {
+		OBS_LOG_INFO(" - %s", p.filename().string().c_str());
+	}
+}
+
+} // namespace foxclip::infra_shared::plugin

--- a/src/infra_shared/plugin/PluginFolderLogger.cpp
+++ b/src/infra_shared/plugin/PluginFolderLogger.cpp
@@ -24,11 +24,10 @@ void logPluginSubfolders(const std::string &pluginDirName)
 		return;
 	}
 
-	const std::string pluginRoot = *fullOpt;
-	const std::filesystem::path rootPath{pluginRoot};
+	const std::filesystem::path rootPath{*fullOpt};
 	const auto subs = DirectoryLister::listSubdirectories(rootPath);
 
-	OBS_LOG_INFO("[foxclip] Plugin folder listing: %s", pluginRoot.c_str());
+	OBS_LOG_INFO("[foxclip] Plugin folder listing: %s", fullOpt->c_str());
 	if (subs.empty()) {
 		OBS_LOG_INFO("[foxclip] (no subfolders found)");
 		return;

--- a/src/infra_shared/plugin/PluginFolderLogger.h
+++ b/src/infra_shared/plugin/PluginFolderLogger.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+
+namespace foxclip::infra_shared::plugin {
+
+// プラグイン用ディレクトリ直下のフォルダー一覧を取得し、OBS のログに出力する。
+// 失敗時は WARN を出して何も列挙しない。例外は投げない。
+void logPluginSubfolders(const std::string &pluginDirName);
+
+} // namespace foxclip::infra_shared::plugin


### PR DESCRIPTION
- infra_shared/fs に DirectoryLister を新規追加
  - std::filesystem を利用してサブディレクトリ一覧を取得する共通ユーティリティ
  - エラーは例外ではなく空ベクタ返却で扱う
- infra_shared/plugin に PluginFolderLogger を新規追加
  - 任意のタイミングで呼び出し可能な関数 logPluginSubfolders() を提供
  - プラグインディレクトリを解決して DirectoryLister で列挙し、OBS_LOG_INFO/WARN で出力
- plugin-main.cpp を修正
  - 起動時に foxclip-plugins ディレクトリの存在をチェック
  - 追加で logPluginSubfolders("foxclip-plugins") を呼び出してフォルダ一覧をログ出力

目的: 起動時および必要に応じてプラグイン用フォルダの一覧をログに出せるようにし、デバッグ性と拡張性を向上。


## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
* **anyは使わない**

  * 対象は **`std::any` 禁止** の意味、と明記してください。
  * 代替: 具体型／`std::variant`／テンプレートで表現。レビューは `[必須]`（型安全性）で指摘。

* **命名**

  * 型／クラス名: `UpperCamel`、関数・変数: `lowerCamel` を「ファイル全域で統一」。
  * 定数は `kUpperCamel`（例: `kMaxSize`）を推奨（衝突回避・視認性）。
  * テスト用の fixture, matcher も命名規約の例外にしない（統一が楽）。

* **予約識別子（アンダースコア関連）**

  * 「アンダースコア＋大文字で始まる名前」「連続する二つのアンダースコア」は**予約**なので**全面禁止**。
  * **大域（グローバル）名前空間でアンダースコア始まり**も**禁止**（標準予約）。
  * これらは\*\*`[必須]`違反\*\*として扱い、機械検出を必須化（後述）。

* **std 名前空間**

  * **`namespace std { ... }` での追加・変更は禁止（未定義動作）**。
  * ただし標準が許容する**ユーザー定義型に対する既存テンプレートの**明示的**特殊化**（例: `std::hash<MyType>`、`std::formatter<MyType>`）は可。
  * 可否を規約に明文化（「フル特殊化のみ可・部分特殊化不可」など）。

* **引数は 3～5 個を目安**

  * 6 個以上は**構造体に束ねる** or **Builder** を推奨（レビューは `[推奨]`）。
  * 「可変長引数」「多数の bool 引数」も原則禁止。意味不明瞭なら `[必須]` で差戻し。

* **モジュール化（infra_shared/**）**

  * **複数モジュールから使う可能性のある処理は** `infra_shared/<機能区分>/` に配置。
  * インタフェースは最小依存（PIMPL/前方宣言）＋ **安定 ABI/ヘッダ** を意識。
  * CMake は `infra_shared_*` を**静的ライブラリ**に分離し、**依存の向き**（アプリ→shared）を厳守。

<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->