### PR TITLE
feature/#12 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(
     src/infra_shared/fs/PathResolver.cpp
     src/infra_shared/fs/DirectoryLister.cpp
     src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+    src/infra_shared/ui/menu/app/ObsMenuRegistry.cpp
     src/infra_shared/log/ObsLogger.c
     src/infra_shared/config/path/ObsConfigPathProvider.cpp
     src/infra_shared/plugin/FoxclipPluginHost.cpp

--- a/src/app/plugin-main.cpp
+++ b/src/app/plugin-main.cpp
@@ -16,6 +16,10 @@
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 
+// 予約識別子回避＆規約どおり kUpperCamel で定数化
+static const char *const kTestOriginalMenuId = "TestOriginal";
+static const char *const kTestOriginalActionLogId = "TestOriginal.Log";
+
 static void onLogAction()
 {
 	OBS_LOG_INFO("Top menu action clicked (version %s)", PLUGIN_VERSION);
@@ -48,13 +52,13 @@ bool obs_module_load(void)
 	// ▼▼ ここからトップレベルメニューを追加 ▼▼
 	// ID は英数字（objectName用）、表示名は日本語
 	foxclip::ui::menu::ObsMenuRegistry::ensureTopLevelMenu(
-		/*topMenuId=*/"TestOriginal",
+		/*topMenuId=*/kTestOriginalMenuId,
 		/*visibleTitle=*/QObject::tr(u8"テストオリジナルメニュー"));
 
 	// メニュー配下にクリック可能な項目を1つ追加（押されたらログ）
 	foxclip::ui::menu::ObsMenuRegistry::addMenuAction(
-		/*topMenuId=*/"TestOriginal",
-		/*actionId=*/"TestOriginal.Log",
+		/*topMenuId=*/kTestOriginalMenuId,
+		/*actionId=*/kTestOriginalActionLogId,
 		/*title=*/QObject::tr(u8"ログ出力"),
 		/*onTriggered=*/onLogAction);
 

--- a/src/app/plugin-main.cpp
+++ b/src/app/plugin-main.cpp
@@ -11,9 +11,15 @@
 #include "infra_shared/config/build/plugin-config.h"
 #include "infra_shared/plugin/FoxclipPluginHost.h"
 #include "infra_shared/plugin/PluginFolderLogger.h"
+#include "infra_shared/ui/menu/app/ObsMenuRegistry.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
+
+static void onLogAction()
+{
+	OBS_LOG_INFO("Top menu action clicked (version %s)", PLUGIN_VERSION);
+}
 
 bool obs_module_load(void)
 {
@@ -38,6 +44,19 @@ bool obs_module_load(void)
 	}
 
 	foxclip::infra_shared::plugin::logPluginSubfolders(pluginDirName);
+
+	// ▼▼ ここからトップレベルメニューを追加 ▼▼
+	// ID は英数字（objectName用）、表示名は日本語
+	foxclip::ui::menu::ObsMenuRegistry::ensureTopLevelMenu(
+		/*topMenuId=*/"TestOriginal",
+		/*visibleTitle=*/QObject::tr(u8"テストオリジナルメニュー"));
+
+	// メニュー配下にクリック可能な項目を1つ追加（押されたらログ）
+	foxclip::ui::menu::ObsMenuRegistry::addMenuAction(
+		/*topMenuId=*/"TestOriginal",
+		/*actionId=*/"TestOriginal.Log",
+		/*title=*/QObject::tr(u8"ログ出力"),
+		/*onTriggered=*/onLogAction);
 
 	// Tools メニューにカスタム QAction を追加
 	const char *label = obs_module_text("Tools.Menu.FoxClip");

--- a/src/app/plugin-main.cpp
+++ b/src/app/plugin-main.cpp
@@ -58,9 +58,8 @@ bool obs_module_load(void)
 	// メニュー配下にクリック可能な項目を1つ追加（押されたらログ）
 	foxclip::ui::menu::ObsMenuRegistry::addMenuAction(
 		/*topMenuId=*/kTestOriginalMenuId,
-		/*actionId=*/kTestOriginalActionLogId,
-		/*title=*/QObject::tr(u8"ログ出力"),
-		/*onTriggered=*/onLogAction);
+		/*props=*/foxclip::ui::menu::ActionProperties{kTestOriginalActionLogId, QObject::tr(u8"ログ出力"),
+							      onLogAction, false});
 
 	// Tools メニューにカスタム QAction を追加
 	const char *label = obs_module_text("Tools.Menu.FoxClip");
@@ -85,5 +84,7 @@ bool obs_module_load(void)
 
 void obs_module_unload(void)
 {
+	// 追加: 生成した QMenu/QAction を確実に破棄
+	foxclip::ui::menu::ObsMenuRegistry::teardownAll();
 	OBS_LOG_INFO("plugin unloaded");
 }

--- a/src/infra_shared/ui/common/domain/UiTypes.h
+++ b/src/infra_shared/ui/common/domain/UiTypes.h
@@ -1,0 +1,8 @@
+// src/infra_shared/ui/common/domain/UiTypes.h
+#pragma once
+#include <functional>
+
+namespace foxclip::ui::common {
+// UIスレッドで実行される引数なしコールバック
+using UiVoidFn = std::function<void()>;
+} // namespace foxclip::ui::common

--- a/src/infra_shared/ui/menu/app/ObsMenuRegistry.cpp
+++ b/src/infra_shared/ui/menu/app/ObsMenuRegistry.cpp
@@ -1,0 +1,173 @@
+// src/infra_shared/ui/menu/app/ObsMenuRegistry.cpp
+#include "ObsMenuRegistry.h"
+
+#include <obs-frontend-api.h>
+#include <QApplication>
+#include <QMainWindow>
+#include <QMenuBar>
+#include <QMenu>
+#include <QAction>
+#include <QPointer>
+#include <QMetaObject>
+#include <QThread>
+
+namespace foxclip::ui::menu {
+
+namespace {
+struct ActionRecord {
+	QPointer<QAction> action;
+	UiVoidFn callback;
+};
+
+struct MenuRecord {
+	QPointer<QMenu> menu;
+	std::unordered_map<ActionId, ActionRecord> actions;
+};
+
+std::unordered_map<MenuId, MenuRecord> &menuMap()
+{
+	static std::unordered_map<MenuId, MenuRecord> s;
+	return s;
+}
+
+std::mutex &mtx()
+{
+	static std::mutex s;
+	return s;
+}
+
+// UI スレッドで func を実行（Qt 標準ディスパッチ版）
+inline void callUi(std::function<void()> func)
+{
+	auto *app = QCoreApplication::instance();
+	if (!app) { // 念のため：アプリがまだ無いなら同期呼び出し（起動初期など）
+		func();
+		return;
+	}
+	// すでに UI スレッドならそのまま実行
+	if (QThread::currentThread() == app->thread()) {
+		func();
+		return;
+	}
+	// UI スレッドに投げる
+	QMetaObject::invokeMethod(app, [f = std::move(func)]() { f(); }, Qt::QueuedConnection);
+}
+
+inline QMainWindow *mainWindow()
+{
+	return reinterpret_cast<QMainWindow *>(obs_frontend_get_main_window());
+}
+
+} // namespace
+
+void ObsMenuRegistry::ensureTopLevelMenu(const MenuId &topMenuId, const QString &visibleTitle)
+{
+	{
+		std::lock_guard<std::mutex> lock(mtx());
+		if (menuMap().count(topMenuId)) {
+			if (auto m = menuMap().at(topMenuId).menu) {
+				if (!visibleTitle.isEmpty())
+					m->setTitle(visibleTitle);
+			}
+			return;
+		}
+	}
+
+	callUi([=]() {
+		auto *mw = mainWindow();
+		if (!mw)
+			return;
+		auto *bar = mw->menuBar();
+		if (!bar)
+			return;
+
+		// 既存検索（objectName）
+		for (auto *act : bar->actions()) {
+			if (auto *menu = act->menu()) {
+				if (menu->objectName() == QString::fromStdString(topMenuId)) {
+					std::lock_guard<std::mutex> lock(mtx());
+					menuMap()[topMenuId] = MenuRecord{menu, {}};
+					if (!visibleTitle.isEmpty())
+						menu->setTitle(visibleTitle);
+					return;
+				}
+			}
+		}
+
+		// 新規作成
+		auto *menu = new QMenu(bar);
+		menu->setObjectName(QString::fromStdString(topMenuId));
+		menu->setTitle(visibleTitle.isEmpty() ? QString::fromStdString(topMenuId) : visibleTitle);
+		bar->addMenu(menu);
+
+		std::lock_guard<std::mutex> lock(mtx());
+		menuMap()[topMenuId] = MenuRecord{menu, {}};
+	});
+}
+
+void ObsMenuRegistry::addMenuAction(const MenuId &topMenuId, const ActionId &actionId, const QString &title,
+				    UiVoidFn onTriggered, bool checkable)
+{
+	ensureTopLevelMenu(topMenuId);
+
+	callUi([=]() mutable {
+		std::lock_guard<std::mutex> lock(mtx());
+		auto it = menuMap().find(topMenuId);
+		if (it == menuMap().end() || !it->second.menu)
+			return;
+
+		auto &rec = it->second;
+
+		auto aIt = rec.actions.find(actionId);
+		if (aIt != rec.actions.end()) {
+			if (aIt->second.action) {
+				aIt->second.action->setText(title);
+				aIt->second.callback = std::move(onTriggered);
+				return;
+			} else {
+				rec.actions.erase(aIt);
+			}
+		}
+
+		QAction *act = new QAction(title, rec.menu);
+		act->setCheckable(checkable);
+
+		QObject::connect(act, &QAction::triggered, [actionId](bool) {
+			std::lock_guard<std::mutex> lock2(mtx());
+			for (auto &[mid, mrec] : menuMap()) {
+				auto f = mrec.actions.find(actionId);
+				if (f != mrec.actions.end() && f->second.callback) {
+					f->second.callback(); // UIスレッド内
+					break;
+				}
+			}
+		});
+
+		rec.menu->addAction(act);
+		rec.actions.emplace(actionId, ActionRecord{act, std::move(onTriggered)});
+	});
+}
+
+void ObsMenuRegistry::teardownAll()
+{
+	callUi([]() {
+		std::lock_guard<std::mutex> lock(mtx());
+		for (auto &[mid, mrec] : menuMap()) {
+			if (mrec.menu) {
+				for (auto &[aid, arec] : mrec.actions) {
+					if (arec.action)
+						mrec.menu->removeAction(arec.action);
+				}
+				if (auto *bar = mrec.menu->parentWidget()) {
+					if (auto *menuBar = qobject_cast<QMenuBar *>(bar)) {
+						menuBar->removeAction(mrec.menu->menuAction());
+					}
+				}
+				mrec.menu->deleteLater();
+			}
+		}
+		menuMap().clear();
+	});
+}
+
+} // namespace foxclip::ui::menu

--- a/src/infra_shared/ui/menu/app/ObsMenuRegistry.cpp
+++ b/src/infra_shared/ui/menu/app/ObsMenuRegistry.cpp
@@ -66,7 +66,8 @@ static MenuRecord &findOrCreateMenuLocked(const MenuId &topMenuId, QMenuBar *bar
 	// 3) 無ければ作成
 	if (!found) {
 		found = new QMenu(bar);
-		found->setObjectName(QString::fromStdString(topMenuId));
+		// ループ前に作った qTopMenuId を再利用（余分な変換を回避）
+		found->setObjectName(qTopMenuId);
 		bar->addMenu(found);
 	}
 

--- a/src/infra_shared/ui/menu/app/ObsMenuRegistry.h
+++ b/src/infra_shared/ui/menu/app/ObsMenuRegistry.h
@@ -9,9 +9,8 @@ class ObsMenuRegistry {
 public:
 	static void ensureTopLevelMenu(const MenuId &topMenuId, const QString &visibleTitle = QString());
 
-	static void addMenuAction(const MenuId &topMenuId, const ActionId &actionId, const QString &title,
-				  UiVoidFn onTriggered, bool checkable = false);
-
+	// 引数を ActionProperties に集約
+	static void addMenuAction(const MenuId &topMenuId, ActionProperties props);
 	static void teardownAll();
 
 private:

--- a/src/infra_shared/ui/menu/app/ObsMenuRegistry.h
+++ b/src/infra_shared/ui/menu/app/ObsMenuRegistry.h
@@ -1,0 +1,21 @@
+// src/infra_shared/ui/menu/app/ObsMenuRegistry.h
+#pragma once
+#include <QString>
+#include "infra_shared/ui/menu/domain/MenuTypes.h"
+
+namespace foxclip::ui::menu {
+
+class ObsMenuRegistry {
+public:
+	static void ensureTopLevelMenu(const MenuId &topMenuId, const QString &visibleTitle = QString());
+
+	static void addMenuAction(const MenuId &topMenuId, const ActionId &actionId, const QString &title,
+				  UiVoidFn onTriggered, bool checkable = false);
+
+	static void teardownAll();
+
+private:
+	ObsMenuRegistry() = delete;
+};
+
+} // namespace foxclip::ui::menu

--- a/src/infra_shared/ui/menu/domain/MenuTypes.h
+++ b/src/infra_shared/ui/menu/domain/MenuTypes.h
@@ -1,6 +1,8 @@
 // src/infra_shared/ui/menu/domain/MenuTypes.h
 #pragma once
 #include <string>
+#include <string>
+#include <QString>
 #include "infra_shared/ui/common/domain/UiTypes.h"
 
 namespace foxclip::ui::menu {

--- a/src/infra_shared/ui/menu/domain/MenuTypes.h
+++ b/src/infra_shared/ui/menu/domain/MenuTypes.h
@@ -9,4 +9,12 @@ using MenuId = std::string;   // トップレベルメニュー識別子
 using ActionId = std::string; // QAction識別子
 using UiVoidFn = foxclip::ui::common::UiVoidFn;
 
+// QAction の属性をまとめた構造体
+struct ActionProperties {
+	ActionId actionId;
+	QString title;
+	UiVoidFn onTriggered;
+	bool checkable = false;
+};
+
 } // namespace foxclip::ui::menu

--- a/src/infra_shared/ui/menu/domain/MenuTypes.h
+++ b/src/infra_shared/ui/menu/domain/MenuTypes.h
@@ -1,0 +1,12 @@
+// src/infra_shared/ui/menu/domain/MenuTypes.h
+#pragma once
+#include <string>
+#include "infra_shared/ui/common/domain/UiTypes.h"
+
+namespace foxclip::ui::menu {
+
+using MenuId = std::string;   // トップレベルメニュー識別子
+using ActionId = std::string; // QAction識別子
+using UiVoidFn = foxclip::ui::common::UiVoidFn;
+
+} // namespace foxclip::ui::menu


### PR DESCRIPTION
- #12 

- infra_shared/ui/menu 以下を新設し、DDD レイヤ構成 (domain/app) に準拠
  - domain/MenuTypes.h: MenuId/ActionId/UiVoidFn などの型定義
  - app/ObsMenuRegistry.{h,cpp}: QMenu/QAction を管理する共通API
    - ensureTopLevelMenu: トップレベルメニューを冪等的に作成
    - addMenuAction: 配下に QAction を追加（コールバック登録）
    - teardownAll: プラグイン終了時にクリーンアップ
- plugin-main.cpp で ObsMenuRegistry を利用し、 「てすとオリジナルメニュー」配下に「ログ出力」アクションを追加 → クリック時に OBS_LOG_INFO を出力するサンプルを実装
- これにより features 側からも簡単に独自メニューを追加できる基盤を整備


## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
* **anyは使わない**

  * 対象は **`std::any` 禁止** の意味、と明記してください。
  * 代替: 具体型／`std::variant`／テンプレートで表現。レビューは `[必須]`（型安全性）で指摘。

* **命名**

  * 型／クラス名: `UpperCamel`、関数・変数: `lowerCamel` を「ファイル全域で統一」。
  * 定数は `kUpperCamel`（例: `kMaxSize`）を推奨（衝突回避・視認性）。
  * テスト用の fixture, matcher も命名規約の例外にしない（統一が楽）。

* **予約識別子（アンダースコア関連）**

  * 「アンダースコア＋大文字で始まる名前」「連続する二つのアンダースコア」は**予約**なので**全面禁止**。
  * **大域（グローバル）名前空間でアンダースコア始まり**も**禁止**（標準予約）。
  * これらは\*\*`[必須]`違反\*\*として扱い、機械検出を必須化（後述）。

* **std 名前空間**

  * **`namespace std { ... }` での追加・変更は禁止（未定義動作）**。
  * ただし標準が許容する**ユーザー定義型に対する既存テンプレートの**明示的**特殊化**（例: `std::hash<MyType>`、`std::formatter<MyType>`）は可。
  * 可否を規約に明文化（「フル特殊化のみ可・部分特殊化不可」など）。

* **引数は 3～5 個を目安**

  * 6 個以上は**構造体に束ねる** or **Builder** を推奨（レビューは `[推奨]`）。
  * 「可変長引数」「多数の bool 引数」も原則禁止。意味不明瞭なら `[必須]` で差戻し。

* **モジュール化（infra_shared/**）**

  * **複数モジュールから使う可能性のある処理は** `infra_shared/<機能区分>/` に配置。
  * インタフェースは最小依存（PIMPL/前方宣言）＋ **安定 ABI/ヘッダ** を意識。
  * CMake は `infra_shared_*` を**静的ライブラリ**に分離し、**依存の向き**（アプリ→shared）を厳守。

<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->