### PR TITLE
Feature/#60

### DIFF
--- a/include/foxclip/plugin_api.h
+++ b/include/foxclip/plugin_api.h
@@ -7,7 +7,10 @@
 /* ABI 定義 */
 #define FOXCLIP_API_ABI 1
 
+// ログ出力
 typedef void(FOXCLIP_CALL *FoxclipEventCallback)(const char *event, const char *payload, void *user);
+// 録画開始
+typedef int(FOXCLIP_CALL *FoxclipRecordStartFn)(const struct FoxclipRecorderStartOptions *opts);
 
 typedef struct FoxclipApiV1 {
 	int abi; /* == FOXCLIP_API_ABI */
@@ -16,6 +19,8 @@ typedef struct FoxclipApiV1 {
 	void(FOXCLIP_CALL *logVa)(FoxclipLogLevel, const char *tag, const char *fmt, va_list);
 	int(FOXCLIP_CALL *registerEventHandler)(const char *event, FoxclipEventCallback cb, void *user);
 	int(FOXCLIP_CALL *unregisterEventHandler)(const char *event, FoxclipEventCallback cb, void *user);
+
+	FoxclipRecordStartFn recordStart; /* 録画開始関数 */
 } FoxclipApiV1;
 
 typedef FoxclipApiV1 FoxclipApi;

--- a/include/foxclip/recording.h
+++ b/include/foxclip/recording.h
@@ -1,3 +1,8 @@
 #pragma once
 
-#include "foxclip/recording/recording.h"
+// Convenience header for FoxClip recording functionality
+// Includes all recording-related headers
+
+#include "foxclip/recording/error.h"
+#include "foxclip/recording/events.h"
+#include "foxclip/recording/start.h"

--- a/include/foxclip/recording.h
+++ b/include/foxclip/recording.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "foxclip/recording/recording.h"

--- a/include/foxclip/recording/error.h
+++ b/include/foxclip/recording/error.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum FoxclipRecorderError {
+	FOXCLIP_RECORDER_OK = 0,
+	FOXCLIP_RECORDER_E_NOT_SUPPORTED = -1, /* ホストが本機能を未実装 */
+	FOXCLIP_RECORDER_E_INVALID_ARG = -2,
+	FOXCLIP_RECORDER_E_BUSY = -3,          /* 競合(既に開始中/ロック) */
+	FOXCLIP_RECORDER_E_BACKEND_ERROR = -4, /* OBS側エラー */
+	FOXCLIP_RECORDER_E_TIMEOUT = -5,       /* waitUntilStartedMs でタイムアウト */
+	FOXCLIP_RECORDER_E_THREADING = -6,     /* スレッド/ディスパッチの問題 */
+} FoxclipRecorderError;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/include/foxclip/recording/events.h
+++ b/include/foxclip/recording/events.h
@@ -1,0 +1,9 @@
+#pragma once
+/* 文字列イベント名（payloadは JSON 文字列推奨） */
+#define FOXCLIP_EVENT_RECORDER_STARTING   "recorder.starting"
+#define FOXCLIP_EVENT_RECORDER_STARTED    "recorder.started"
+#define FOXCLIP_EVENT_RECORDER_START_FAIL "recorder.start_failed"
+
+/* 例: start_failed の payload (JSON)
+   { "code": -4, "message": "backend error", "detail": "..." }
+*/

--- a/include/foxclip/recording/start.h
+++ b/include/foxclip/recording/start.h
@@ -1,0 +1,53 @@
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdbool.h>
+#include "foxclip/core/export.h"
+#include "foxclip/recorder/error.h"
+
+/* 将来拡張のためのフラグ */
+typedef enum FoxclipRecorderStartFlags {
+	FOXCLIP_RECORDER_START_NONE = 0,
+	/* 例: 配信中でも録画を開始してよいか */
+	FOXCLIP_RECORDER_START_ALLOW_IF_STREAMING = 1 << 0,
+	/* 例: 既に録画中なら成功扱いにする (冪等) */
+	FOXCLIP_RECORDER_START_IDEMPOTENT_OK = 1 << 1,
+} FoxclipRecorderStartFlags;
+
+/* 拡張可能な Options（size により後方互換） */
+typedef struct FoxclipRecorderStartOptions {
+	size_t size;              /* 必須: 構造体サイズ (= sizeof(FoxclipRecorderStartOptions)) */
+	unsigned int flags;       /* FoxclipRecorderStartFlags のビット和 */
+	const char *outputName;   /* 任意: 特定の出力(フェーダ名等)を明示。NULLならデフォルト */
+	const char *pathOverride; /* 任意: 保存先パスを一時的に上書き（NULLで無効） */
+	int waitUntilStartedMs;   /* 任意: started 確定まで待つ最大ミリ秒(0以下で待たない) */
+	/* ここから下は将来予約領域。NULL/0 初期化必須。 */
+	const char *profileName;     /* 予約: プロファイル切替を伴う開始 */
+	const char *sceneCollection; /* 予約: シーンコレクション切替を伴う開始 */
+	void *reserved0;
+	void *reserved1;
+} FoxclipRecorderStartOptions;
+
+/* 推奨初期化マクロ */
+#define FOXCLIP_RECORDER_START_OPTIONS_INIT \
+  {                                         \
+    sizeof(FoxclipRecorderStartOptions),    \
+    FOXCLIP_RECORDER_START_NONE,            \
+    NULL, /* outputName */                  \
+    NULL, /* pathOverride */                \
+    0,    /* waitUntilStartedMs */          \
+    NULL, /* profileName */                 \
+    NULL, /* sceneCollection */             \
+    NULL, /* reserved0 */                   \
+    NULL  /* reserved1 */                   \
+  }
+
+/* C 公開 API：成功=0、失敗=<0 (FoxclipRecorderError) */
+FOXCLIP_EXTERN int FOXCLIP_CALL foxclipRecordStart(const FoxclipRecorderStartOptions *opts);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/include/foxclip/recording/start.h
+++ b/include/foxclip/recording/start.h
@@ -6,7 +6,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdbool.h>
 #include "foxclip/core/export.h"
-#include "foxclip/recorder/error.h"
+#include "foxclip/recording/error.h"
 
 /* 将来拡張のためのフラグ */
 typedef enum FoxclipRecorderStartFlags {

--- a/src/features/startup_check/domain/StartupCheckService.cpp
+++ b/src/features/startup_check/domain/StartupCheckService.cpp
@@ -17,20 +17,21 @@ Result StartupCheckService::run()
 {
 	// basePath_ が空なら requiredName を「そのままフルパス」として扱う
 	std::filesystem::path targetPath = basePath.empty() ? std::filesystem::path(policy.requiredName)
-						    : (std::filesystem::path(basePath) / policy.requiredName);
+							    : (std::filesystem::path(basePath) / policy.requiredName);
 	std::string target = targetPath.string();
-	
-	OBS_LOG_INFO("[StartupCheckService] Checking directory - basePath: '%s', requiredName: '%s', target: '%s'", 
-		basePath.c_str(), policy.requiredName.c_str(), target.c_str());
-	
+
+	OBS_LOG_INFO("[StartupCheckService] Checking directory - basePath: '%s', requiredName: '%s', target: '%s'",
+		     basePath.c_str(), policy.requiredName.c_str(), target.c_str());
+
 	if (!&checker) {
 		OBS_LOG_ERROR("[StartupCheckService] IDirectoryChecker is null");
 		return Result::failure("IDirectoryChecker is null");
 	}
-	
+
 	OBS_LOG_INFO("[StartupCheckService] Checking if directory exists: '%s'", target.c_str());
 	if (!checker.existsDir(target)) {
-		OBS_LOG_INFO("[StartupCheckService] Directory doesn't exist, attempting to create: '%s'", target.c_str());
+		OBS_LOG_INFO("[StartupCheckService] Directory doesn't exist, attempting to create: '%s'",
+			     target.c_str());
 		// 無ければ作成を試みる
 		std::error_code ec;
 		const bool ok = creator.createIfMissing(target, ec);
@@ -38,17 +39,18 @@ Result StartupCheckService::run()
 			OBS_LOG_ERROR("[StartupCheckService] Directory creation failed for '%s'", target.c_str());
 			if (ec) {
 				return Result::failure("必須ディレクトリ '" + policy.requiredName +
-					       "' の作成に失敗: " + ec.message());
+						       "' の作成に失敗: " + ec.message());
 			}
 			return Result::failure("必須ディレクトリ '" + policy.requiredName + "' の作成に失敗");
 		}
-		
+
 		OBS_LOG_INFO("[StartupCheckService] Directory creation succeeded, verifying: '%s'", target.c_str());
 		// 念のため再チェック
 		if (!checker.existsDir(target)) {
-			OBS_LOG_ERROR("[StartupCheckService] Directory verification failed after creation: '%s'", target.c_str());
+			OBS_LOG_ERROR("[StartupCheckService] Directory verification failed after creation: '%s'",
+				      target.c_str());
 			return Result::failure("必須ディレクトリ '" + policy.requiredName +
-				       "' を作成後に確認できませんでした");
+					       "' を作成後に確認できませんでした");
 		}
 		OBS_LOG_INFO("[StartupCheckService] Directory successfully created and verified: '%s'", target.c_str());
 		return Result::success("必須ディレクトリ '" + policy.requiredName + "' を新規作成しました");

--- a/src/features/startup_check/domain/StartupCheckService.cpp
+++ b/src/features/startup_check/domain/StartupCheckService.cpp
@@ -1,5 +1,6 @@
 #include <filesystem>
 #include "StartupCheckService.h"
+#include "infra_shared/log/ObsLogger.h"
 
 namespace foxclip::startup_check::domain {
 
@@ -16,29 +17,43 @@ Result StartupCheckService::run()
 {
 	// basePath_ が空なら requiredName を「そのままフルパス」として扱う
 	std::filesystem::path targetPath = basePath.empty() ? std::filesystem::path(policy.requiredName)
-							    : (std::filesystem::path(basePath) / policy.requiredName);
+						    : (std::filesystem::path(basePath) / policy.requiredName);
 	std::string target = targetPath.string();
+	
+	OBS_LOG_INFO("[StartupCheckService] Checking directory - basePath: '%s', requiredName: '%s', target: '%s'", 
+		basePath.c_str(), policy.requiredName.c_str(), target.c_str());
+	
 	if (!&checker) {
+		OBS_LOG_ERROR("[StartupCheckService] IDirectoryChecker is null");
 		return Result::failure("IDirectoryChecker is null");
 	}
+	
+	OBS_LOG_INFO("[StartupCheckService] Checking if directory exists: '%s'", target.c_str());
 	if (!checker.existsDir(target)) {
+		OBS_LOG_INFO("[StartupCheckService] Directory doesn't exist, attempting to create: '%s'", target.c_str());
 		// 無ければ作成を試みる
 		std::error_code ec;
 		const bool ok = creator.createIfMissing(target, ec);
 		if (!ok) {
+			OBS_LOG_ERROR("[StartupCheckService] Directory creation failed for '%s'", target.c_str());
 			if (ec) {
 				return Result::failure("必須ディレクトリ '" + policy.requiredName +
-						       "' の作成に失敗: " + ec.message());
+					       "' の作成に失敗: " + ec.message());
 			}
 			return Result::failure("必須ディレクトリ '" + policy.requiredName + "' の作成に失敗");
 		}
+		
+		OBS_LOG_INFO("[StartupCheckService] Directory creation succeeded, verifying: '%s'", target.c_str());
 		// 念のため再チェック
 		if (!checker.existsDir(target)) {
+			OBS_LOG_ERROR("[StartupCheckService] Directory verification failed after creation: '%s'", target.c_str());
 			return Result::failure("必須ディレクトリ '" + policy.requiredName +
-					       "' を作成後に確認できませんでした");
+				       "' を作成後に確認できませんでした");
 		}
+		OBS_LOG_INFO("[StartupCheckService] Directory successfully created and verified: '%s'", target.c_str());
 		return Result::success("必須ディレクトリ '" + policy.requiredName + "' を新規作成しました");
 	}
+	OBS_LOG_INFO("[StartupCheckService] Directory already exists: '%s'", target.c_str());
 	return Result::success("必須ディレクトリ '" + policy.requiredName + "' が存在します");
 }
 

--- a/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
@@ -1,4 +1,5 @@
 #include "StdFsDirectoryCreator.h"
+#include "infra_shared/log/ObsLogger.h"
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -8,25 +9,65 @@ namespace foxclip::startup_check::infrastructure {
 bool StdFsDirectoryCreator::createIfMissing(const std::string &path, std::error_code &ec)
 {
 	ec.clear();
-	// 既にある場合は true を返す（何もしない）
-	if (fs::exists(path, ec)) {
-		if (ec)
-			return false;
-		if (fs::is_directory(path, ec))
-			return true;
-
-		// 存在はするがディレクトリではない
-		if (!ec)
-			ec = std::make_error_code(std::errc::file_exists);
+	OBS_LOG_INFO("[StdFsDirectoryCreator] Attempting to create directory: '%s'", path.c_str());
+	
+	if (path.empty()) {
+		OBS_LOG_ERROR("[StdFsDirectoryCreator] Empty path provided");
+		ec = std::make_error_code(std::errc::invalid_argument);
 		return false;
 	}
-	// 足りない親までまとめて作成
-	const bool ok = fs::create_directories(path, ec);
-	if (ec)
+	
+	// Check if already exists and is a directory
+	OBS_LOG_INFO("[StdFsDirectoryCreator] Checking if directory exists: '%s'", path.c_str());
+	if (fs::exists(path, ec)) {
+		if (ec) {
+			OBS_LOG_ERROR("[StdFsDirectoryCreator] Error checking existence: %s", ec.message().c_str());
+			return false;
+		}
+		OBS_LOG_INFO("[StdFsDirectoryCreator] Path exists, checking if it's a directory");
+		if (fs::is_directory(path, ec)) {
+			OBS_LOG_INFO("[StdFsDirectoryCreator] Directory already exists: '%s'", path.c_str());
+			return true; // Already exists as directory
+		}
+		
+		// Exists but is not a directory
+		OBS_LOG_ERROR("[StdFsDirectoryCreator] Path exists but is not a directory: '%s'", path.c_str());
+		if (!ec) {
+			ec = std::make_error_code(std::errc::file_exists);
+		}
 		return false;
-	// create_directories は「作ったら true / 既存なら false」を返すが、
-	// 我々の API としては「存在すれば成功」で良いので true を返す
-	return ok || fs::exists(path, ec);
+	}
+	
+	// Clear "file not found" error - this is expected when creating new directories
+	if (ec) {
+		OBS_LOG_INFO("[StdFsDirectoryCreator] Directory doesn't exist (expected), error was: %s", ec.message().c_str());
+		ec.clear();
+	}
+	
+	// Create directory structure
+	OBS_LOG_INFO("[StdFsDirectoryCreator] Creating directory structure: '%s'", path.c_str());
+	const bool created = fs::create_directories(path, ec);
+	if (ec) {
+		OBS_LOG_ERROR("[StdFsDirectoryCreator] Failed to create directory: %s", ec.message().c_str());
+		return false; // Creation failed
+	}
+	
+	OBS_LOG_INFO("[StdFsDirectoryCreator] Directory creation result: %s, path: '%s'", 
+		created ? "created new" : "already existed", path.c_str());
+	
+	// Verify creation was successful
+	std::error_code verifyEc;
+	if (fs::exists(path, verifyEc) && fs::is_directory(path, verifyEc)) {
+		OBS_LOG_INFO("[StdFsDirectoryCreator] Directory creation verified successfully: '%s'", path.c_str());
+		return true;
+	} else {
+		OBS_LOG_ERROR("[StdFsDirectoryCreator] Directory creation verification failed: '%s', verify error: %s", 
+			path.c_str(), verifyEc.message().c_str());
+		if (!ec) {
+			ec = verifyEc;
+		}
+		return false;
+	}
 }
 
 } // namespace foxclip::startup_check::infrastructure

--- a/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
+++ b/src/features/startup_check/infrastructure/StdFsDirectoryCreator.cpp
@@ -10,13 +10,13 @@ bool StdFsDirectoryCreator::createIfMissing(const std::string &path, std::error_
 {
 	ec.clear();
 	OBS_LOG_INFO("[StdFsDirectoryCreator] Attempting to create directory: '%s'", path.c_str());
-	
+
 	if (path.empty()) {
 		OBS_LOG_ERROR("[StdFsDirectoryCreator] Empty path provided");
 		ec = std::make_error_code(std::errc::invalid_argument);
 		return false;
 	}
-	
+
 	// Check if already exists and is a directory
 	OBS_LOG_INFO("[StdFsDirectoryCreator] Checking if directory exists: '%s'", path.c_str());
 	if (fs::exists(path, ec)) {
@@ -29,7 +29,7 @@ bool StdFsDirectoryCreator::createIfMissing(const std::string &path, std::error_
 			OBS_LOG_INFO("[StdFsDirectoryCreator] Directory already exists: '%s'", path.c_str());
 			return true; // Already exists as directory
 		}
-		
+
 		// Exists but is not a directory
 		OBS_LOG_ERROR("[StdFsDirectoryCreator] Path exists but is not a directory: '%s'", path.c_str());
 		if (!ec) {
@@ -37,13 +37,14 @@ bool StdFsDirectoryCreator::createIfMissing(const std::string &path, std::error_
 		}
 		return false;
 	}
-	
+
 	// Clear "file not found" error - this is expected when creating new directories
 	if (ec) {
-		OBS_LOG_INFO("[StdFsDirectoryCreator] Directory doesn't exist (expected), error was: %s", ec.message().c_str());
+		OBS_LOG_INFO("[StdFsDirectoryCreator] Directory doesn't exist (expected), error was: %s",
+			     ec.message().c_str());
 		ec.clear();
 	}
-	
+
 	// Create directory structure
 	OBS_LOG_INFO("[StdFsDirectoryCreator] Creating directory structure: '%s'", path.c_str());
 	const bool created = fs::create_directories(path, ec);
@@ -51,18 +52,18 @@ bool StdFsDirectoryCreator::createIfMissing(const std::string &path, std::error_
 		OBS_LOG_ERROR("[StdFsDirectoryCreator] Failed to create directory: %s", ec.message().c_str());
 		return false; // Creation failed
 	}
-	
-	OBS_LOG_INFO("[StdFsDirectoryCreator] Directory creation result: %s, path: '%s'", 
-		created ? "created new" : "already existed", path.c_str());
-	
+
+	OBS_LOG_INFO("[StdFsDirectoryCreator] Directory creation result: %s, path: '%s'",
+		     created ? "created new" : "already existed", path.c_str());
+
 	// Verify creation was successful
 	std::error_code verifyEc;
 	if (fs::exists(path, verifyEc) && fs::is_directory(path, verifyEc)) {
 		OBS_LOG_INFO("[StdFsDirectoryCreator] Directory creation verified successfully: '%s'", path.c_str());
 		return true;
 	} else {
-		OBS_LOG_ERROR("[StdFsDirectoryCreator] Directory creation verification failed: '%s', verify error: %s", 
-			path.c_str(), verifyEc.message().c_str());
+		OBS_LOG_ERROR("[StdFsDirectoryCreator] Directory creation verification failed: '%s', verify error: %s",
+			      path.c_str(), verifyEc.message().c_str());
 		if (!ec) {
 			ec = verifyEc;
 		}

--- a/src/infra_shared/config/path/ObsConfigPathProvider.cpp
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.cpp
@@ -1,4 +1,5 @@
 #include "ObsConfigPathProvider.h"
+#include "infra_shared/log/ObsLogger.h"
 #include <obs-module.h>    // obs_module_config_path
 #include <util/platform.h> // bfree
 #include <memory>
@@ -9,11 +10,15 @@ class ObsConfigPathProvider final : public IConfigPathProvider {
 public:
 	std::string configPath(const std::string &subdir) override
 	{
+		OBS_LOG_INFO("[ObsConfigPathProvider] Requesting config path for subdir: '%s'", subdir.c_str());
 		const char *arg = subdir.empty() ? nullptr : subdir.c_str();
 		char *raw = obs_module_config_path(arg);
-		if (!raw)
+		if (!raw) {
+			OBS_LOG_ERROR("[ObsConfigPathProvider] obs_module_config_path returned null for subdir: '%s'", subdir.c_str());
 			return {};
+		}
 		std::string path(raw);
+		OBS_LOG_INFO("[ObsConfigPathProvider] Config path resolved to: '%s'", path.c_str());
 		bfree(raw);
 		return path;
 	}

--- a/src/infra_shared/config/path/ObsConfigPathProvider.cpp
+++ b/src/infra_shared/config/path/ObsConfigPathProvider.cpp
@@ -14,7 +14,8 @@ public:
 		const char *arg = subdir.empty() ? nullptr : subdir.c_str();
 		char *raw = obs_module_config_path(arg);
 		if (!raw) {
-			OBS_LOG_ERROR("[ObsConfigPathProvider] obs_module_config_path returned null for subdir: '%s'", subdir.c_str());
+			OBS_LOG_ERROR("[ObsConfigPathProvider] obs_module_config_path returned null for subdir: '%s'",
+				      subdir.c_str());
 			return {};
 		}
 		std::string path(raw);

--- a/src/infra_shared/fs/DirectoryLister.cpp
+++ b/src/infra_shared/fs/DirectoryLister.cpp
@@ -5,7 +5,7 @@
 
 namespace foxclip::infra_shared::fs {
 
-std::vector<std::filesystem::path> DirectoryLister::listSubdirectories(const std::filesystem::path &root)
+std::vector<std::filesystem::path> DirectoryLister::listSubDirectories(const std::filesystem::path &root)
 {
 	std::vector<std::filesystem::path> result;
 
@@ -25,8 +25,8 @@ std::vector<std::filesystem::path> DirectoryLister::listSubdirectories(const std
 	}
 
 	for (; it != end; it.increment(ec)) {
-		// increment(ec) でエラーが出ると it==end になりループ終了
-		// → 明示的な ec チェック/クリア処理は不要
+		// increment(ec) でエラーが出ると it==end になりループ終了するため、
+		// 明示的な ec チェックやクリア処理は不要。
 
 		// エントリがディレクトリかどうか（非throw）
 		std::error_code typeEc;

--- a/src/infra_shared/fs/DirectoryLister.h
+++ b/src/infra_shared/fs/DirectoryLister.h
@@ -9,7 +9,7 @@ namespace foxclip::infra_shared::fs {
 // 例外は投げず、アクセス不能などは空ベクタを返す。
 class DirectoryLister {
 public:
-	static std::vector<std::filesystem::path> listSubdirectories(const std::filesystem::path &root);
+	static std::vector<std::filesystem::path> listSubDirectories(const std::filesystem::path &root);
 };
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -28,9 +28,7 @@ bool FileStore::ensureDirectory(const std::string &relativeDirectory, std::error
 		return false;
 
 	// 既に存在するか確認
-	return createDirs(
-		full,
-		ec); 
+	return createDirs(full, ec);
 }
 
 bool FileStore::writeText(const std::string &relativePath, const std::string &utf8Content, std::error_code &ec)

--- a/src/infra_shared/fs/FileStore.cpp
+++ b/src/infra_shared/fs/FileStore.cpp
@@ -18,26 +18,28 @@ bool FileStore::resolvePath(const std::string &rel, std::string &full, std::erro
 	return false;
 }
 
-bool FileStore::ensureDir(const std::string &relDir, std::error_code &ec)
+bool FileStore::ensureDirectory(const std::string &relativeDirectory, std::error_code &ec)
 {
 	ec.clear();
 
 	// パス解決
 	std::string full;
-	if (!resolvePath(relDir, full, ec))
+	if (!resolvePath(relativeDirectory, full, ec))
 		return false;
 
 	// 既に存在するか確認
-	return createDirs(full, ec);
+	return createDirs(
+		full,
+		ec); 
 }
 
-bool FileStore::writeText(const std::string &rel, const std::string &utf8, std::error_code &ec)
+bool FileStore::writeText(const std::string &relativePath, const std::string &utf8Content, std::error_code &ec)
 {
 	ec.clear();
 
 	// パス解決
 	std::string full;
-	if (!resolvePath(rel, full, ec))
+	if (!resolvePath(relativePath, full, ec))
 		return false;
 
 	// 既に存在する場合は何もしない
@@ -54,7 +56,7 @@ bool FileStore::writeText(const std::string &rel, const std::string &utf8, std::
 	}
 
 	// 書き込み
-	ofs.write(utf8.data(), static_cast<std::streamsize>(utf8.size()));
+	ofs.write(utf8Content.data(), static_cast<std::streamsize>(utf8Content.size()));
 	if (!ofs.good()) {
 		// 書き込み途中のエラー（ディスクフルなど）
 		ec = std::make_error_code(std::errc::io_error);
@@ -70,13 +72,13 @@ bool FileStore::writeText(const std::string &rel, const std::string &utf8, std::
 	return true;
 }
 
-bool FileStore::readText(const std::string &rel, std::string &out, std::error_code &ec) const
+bool FileStore::readText(const std::string &relativePath, std::string &output, std::error_code &ec) const
 {
 	ec.clear();
 
 	// パス解決
 	std::string full;
-	if (!resolvePath(rel, full, ec))
+	if (!resolvePath(relativePath, full, ec))
 		return false;
 
 	// ファイルを開く
@@ -92,10 +94,11 @@ bool FileStore::readText(const std::string &rel, std::string &out, std::error_co
 	std::error_code fec;
 	auto sz = stdfs::file_size(full, fec);
 	if (!fec && sz > 0)
-		out.reserve(static_cast<size_t>(sz));
+		output.reserve(static_cast<size_t>(sz));
 
-	// ファイルの内容を読み込む
-	out.assign((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+	// 内容を文字列として読み込み
+	output.assign(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
+
 	// 読み込みに失敗した場合はエラーコードを設定
 	// eof() は正常な終了なので、good() でチェック
 	if (!ifs.good() && !ifs.eof()) {
@@ -106,12 +109,12 @@ bool FileStore::readText(const std::string &rel, std::string &out, std::error_co
 	return true;
 }
 
-bool FileStore::exists(const std::string &rel, std::error_code &ec) const
+bool FileStore::exists(const std::string &relativePath, std::error_code &ec) const
 {
 	ec.clear();
 
 	std::string full;
-	if (!resolvePath(rel, full, ec))
+	if (!resolvePath(relativePath, full, ec))
 		return false;
 
 	return stdfs::exists(full, ec);

--- a/src/infra_shared/fs/FileStore.h
+++ b/src/infra_shared/fs/FileStore.h
@@ -10,10 +10,10 @@ public:
 	explicit FileStore(PathResolver &resolver) : resolver(resolver) {}
 
 	// 相対パスで OK。内部で OBS ルートに解決し、必要なら親ディレクトリ作成。
-	bool writeText(const std::string &rel, const std::string &utf8, std::error_code &ec);
-	bool readText(const std::string &rel, std::string &out, std::error_code &ec) const;
-	bool ensureDir(const std::string &relDir, std::error_code &ec);
-	bool exists(const std::string &rel, std::error_code &ec) const;
+	bool writeText(const std::string &relativePath, const std::string &utf8Content, std::error_code &ec);
+	bool readText(const std::string &relativePath, std::string &output, std::error_code &ec) const;
+	bool ensureDirectory(const std::string &relativeDirectory, std::error_code &ec);
+	bool exists(const std::string &relativePath, std::error_code &ec) const;
 
 private:
 	bool resolvePath(const std::string &rel, std::string &full, std::error_code &ec) const;

--- a/src/infra_shared/fs/FsUtils.cpp
+++ b/src/infra_shared/fs/FsUtils.cpp
@@ -5,32 +5,73 @@ namespace stdfs = std::filesystem;
 
 namespace foxclip::infra_shared::fs {
 
+// Constants following kUpperCamel naming convention
+static constexpr std::size_t kMaxPathLength = 260; // Windows MAX_PATH
+
 bool existsDir(const std::string &pathStr, std::error_code &ec) noexcept
 {
 	ec.clear();
-	// exists と is_directory を std::filesystem 側に明示
-	return stdfs::exists(pathStr, ec) && stdfs::is_directory(pathStr, ec);
+	// Single filesystem call optimization - avoid double error_code check
+	const auto status = stdfs::status(pathStr, ec);
+	if (ec) {
+		return false;
+	}
+	return stdfs::is_directory(status);
 }
 
 bool createDirs(const std::string &pathStr, std::error_code &ec) noexcept
 {
 	ec.clear();
-	if (existsDir(pathStr, ec))
-		return !ec;
-	const bool ok = stdfs::create_directories(pathStr, ec);
-	if (ec)
+	
+	if (pathStr.empty()) {
+		ec = std::make_error_code(std::errc::invalid_argument);
 		return false;
-	// 既存でも成功扱い
-	return ok || existsDir(pathStr, ec);
+	}
+	
+	// Check if directory already exists
+	if (existsDir(pathStr, ec)) {
+		return true; // Already exists, success
+	}
+	
+	// Clear any error from existsDir check (e.g., "file not found" is expected)
+	ec.clear();
+	
+	// Attempt to create the directory structure
+	const bool created = stdfs::create_directories(pathStr, ec);
+	if (ec) {
+		return false; // Creation failed
+	}
+	
+	// create_directories returns false if directory already existed
+	// but we consider that a success case
+	return true;
 }
 
 std::string join(const std::string &base, const std::string &name)
 {
-	return (stdfs::path(base) / stdfs::path(name)).string();
+	// Input validation for better error handling
+	if (base.empty()) {
+		return name;
+	}
+	if (name.empty()) {
+		return base;
+	}
+	
+	// Path length validation
+	const auto result = (stdfs::path(base) / stdfs::path(name)).string();
+	if (result.length() > kMaxPathLength) {
+		// Return empty string to indicate path too long
+		return {};
+	}
+	
+	return result;
 }
 
-bool isAbs(const std::string &pathStr) noexcept
+bool isAbsolute(const std::string &pathStr) noexcept
 {
+	if (pathStr.empty()) {
+		return false;
+	}
 	return stdfs::path(pathStr).is_absolute();
 }
 

--- a/src/infra_shared/fs/FsUtils.cpp
+++ b/src/infra_shared/fs/FsUtils.cpp
@@ -22,26 +22,26 @@ bool existsDir(const std::string &pathStr, std::error_code &ec) noexcept
 bool createDirs(const std::string &pathStr, std::error_code &ec) noexcept
 {
 	ec.clear();
-	
+
 	if (pathStr.empty()) {
 		ec = std::make_error_code(std::errc::invalid_argument);
 		return false;
 	}
-	
+
 	// Check if directory already exists
 	if (existsDir(pathStr, ec)) {
 		return true; // Already exists, success
 	}
-	
+
 	// Clear any error from existsDir check (e.g., "file not found" is expected)
 	ec.clear();
-	
+
 	// Attempt to create the directory structure
 	const bool created = stdfs::create_directories(pathStr, ec);
 	if (ec) {
 		return false; // Creation failed
 	}
-	
+
 	// create_directories returns false if directory already existed
 	// but we consider that a success case
 	return true;
@@ -56,14 +56,14 @@ std::string join(const std::string &base, const std::string &name)
 	if (name.empty()) {
 		return base;
 	}
-	
+
 	// Path length validation
 	const auto result = (stdfs::path(base) / stdfs::path(name)).string();
 	if (result.length() > kMaxPathLength) {
 		// Return empty string to indicate path too long
 		return {};
 	}
-	
+
 	return result;
 }
 

--- a/src/infra_shared/fs/FsUtils.h
+++ b/src/infra_shared/fs/FsUtils.h
@@ -7,6 +7,6 @@ namespace foxclip::infra_shared::fs {
 bool existsDir(const std::string &path, std::error_code &ec) noexcept;
 bool createDirs(const std::string &path, std::error_code &ec) noexcept;
 std::string join(const std::string &base, const std::string &name);
-bool isAbs(const std::string &path) noexcept;
+bool isAbsolute(const std::string &path) noexcept;
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/PathResolver.cpp
+++ b/src/infra_shared/fs/PathResolver.cpp
@@ -9,7 +9,7 @@ namespace stdfs = std::filesystem;
 namespace foxclip::infra_shared::fs {
 
 // Constants following kUpperCamel naming convention
-static constexpr const char* kParentDirRef = "..";
+static constexpr const char *kParentDirRef = "..";
 static constexpr char kWindowsSeparator = '\\';
 static constexpr char kUnixSeparator = '/';
 
@@ -29,62 +29,62 @@ static bool isPathTraversalSafe(const stdfs::path &basePath, const stdfs::path &
 	// Ensure the resolved path is still within the base directory
 	const auto normalizedBase = basePath.lexically_normal();
 	const auto normalizedFull = fullPath.lexically_normal();
-	
-	OBS_LOG_INFO("[PathResolver] Security check - base: '%s', full: '%s'", 
-		normalizedBase.string().c_str(), normalizedFull.string().c_str());
-	
+
+	OBS_LOG_INFO("[PathResolver] Security check - base: '%s', full: '%s'", normalizedBase.string().c_str(),
+		     normalizedFull.string().c_str());
+
 	// Use string comparison for simpler and more reliable check
 	std::string baseStr = normalizedBase.string();
 	const std::string fullStr = normalizedFull.string();
-	
+
 	// Remove trailing slash from base path if present
 	if (!baseStr.empty() && (baseStr.back() == kWindowsSeparator || baseStr.back() == kUnixSeparator)) {
 		baseStr.pop_back();
 		OBS_LOG_INFO("[PathResolver] Removed trailing slash from base: '%s'", baseStr.c_str());
 	}
-	
+
 	// Check if fullPath starts with basePath
 	if (fullStr.length() < baseStr.length()) {
 		OBS_LOG_ERROR("[PathResolver] Full path shorter than base path");
 		return false;
 	}
-	
+
 	// Compare the base portion
 	if (fullStr.substr(0, baseStr.length()) != baseStr) {
 		OBS_LOG_ERROR("[PathResolver] Full path doesn't start with base path");
 		return false;
 	}
-	
+
 	// If lengths are equal, paths are identical (allowed)
 	if (fullStr.length() == baseStr.length()) {
 		OBS_LOG_INFO("[PathResolver] Security check result: PASS (identical paths)");
 		return true;
 	}
-	
+
 	// Check that the next character is a path separator (prevents partial matches)
 	char nextChar = fullStr[baseStr.length()];
 	bool isSeparator = (nextChar == kWindowsSeparator || nextChar == kUnixSeparator);
-	
-	OBS_LOG_INFO("[PathResolver] Security check result: %s (next char: '%c')", 
-		isSeparator ? "PASS" : "FAIL", nextChar);
+
+	OBS_LOG_INFO("[PathResolver] Security check result: %s (next char: '%c')", isSeparator ? "PASS" : "FAIL",
+		     nextChar);
 	return isSeparator;
 }
 
 std::optional<std::string> PathResolver::toFull(const std::string &relative) const
 {
 	OBS_LOG_INFO("[PathResolver] Resolving relative path: '%s'", relative.c_str());
-	
+
 	// Input validation: reject empty, absolute paths, or parent directory references
 	if (relative.empty()) {
 		OBS_LOG_ERROR("[PathResolver] Empty relative path provided");
 		return std::nullopt;
 	}
-	
+
 	if (isAbsolute(relative)) {
 		OBS_LOG_ERROR("[PathResolver] Absolute path rejected: '%s'", relative.c_str());
 		return std::nullopt;
 	}
-	
+
 	if (containsParentRef(relative)) {
 		OBS_LOG_ERROR("[PathResolver] Path contains parent reference (..) rejected: '%s'", relative.c_str());
 		return std::nullopt;
@@ -105,11 +105,13 @@ std::optional<std::string> PathResolver::toFull(const std::string &relative) con
 
 	// Security check: ensure the resolved path stays within base directory
 	if (!isPathTraversalSafe(basePath, fullPath)) {
-		OBS_LOG_ERROR("[PathResolver] Path traversal security check failed for: '%s'", fullPath.string().c_str());
+		OBS_LOG_ERROR("[PathResolver] Path traversal security check failed for: '%s'",
+			      fullPath.string().c_str());
 		return std::nullopt;
 	}
 
-	OBS_LOG_INFO("[PathResolver] Path resolution successful: '%s' -> '%s'", relative.c_str(), fullPath.string().c_str());
+	OBS_LOG_INFO("[PathResolver] Path resolution successful: '%s' -> '%s'", relative.c_str(),
+		     fullPath.string().c_str());
 	return fullPath.string();
 }
 

--- a/src/infra_shared/fs/PathResolver.cpp
+++ b/src/infra_shared/fs/PathResolver.cpp
@@ -1,44 +1,116 @@
 #include "PathResolver.h"
 #include "FsUtils.h"
+#include "infra_shared/log/ObsLogger.h"
 #include <filesystem>
 #include <optional>
 
 namespace stdfs = std::filesystem;
+
 namespace foxclip::infra_shared::fs {
 
-static bool containsParentRef(const std::string &rel)
+// Constants following kUpperCamel naming convention
+static constexpr const char* kParentDirRef = "..";
+static constexpr char kWindowsSeparator = '\\';
+static constexpr char kUnixSeparator = '/';
+
+static bool containsParentRef(const std::string &relativePath)
 {
-	auto p = stdfs::path(rel);
-	for (const auto &part : p) {
-		if (part == "..")
+	const auto path = stdfs::path(relativePath);
+	for (const auto &component : path) {
+		if (component == kParentDirRef) {
 			return true;
+		}
 	}
 	return false;
 }
 
+static bool isPathTraversalSafe(const stdfs::path &basePath, const stdfs::path &fullPath)
+{
+	// Ensure the resolved path is still within the base directory
+	const auto normalizedBase = basePath.lexically_normal();
+	const auto normalizedFull = fullPath.lexically_normal();
+	
+	OBS_LOG_INFO("[PathResolver] Security check - base: '%s', full: '%s'", 
+		normalizedBase.string().c_str(), normalizedFull.string().c_str());
+	
+	// Use string comparison for simpler and more reliable check
+	std::string baseStr = normalizedBase.string();
+	const std::string fullStr = normalizedFull.string();
+	
+	// Remove trailing slash from base path if present
+	if (!baseStr.empty() && (baseStr.back() == kWindowsSeparator || baseStr.back() == kUnixSeparator)) {
+		baseStr.pop_back();
+		OBS_LOG_INFO("[PathResolver] Removed trailing slash from base: '%s'", baseStr.c_str());
+	}
+	
+	// Check if fullPath starts with basePath
+	if (fullStr.length() < baseStr.length()) {
+		OBS_LOG_ERROR("[PathResolver] Full path shorter than base path");
+		return false;
+	}
+	
+	// Compare the base portion
+	if (fullStr.substr(0, baseStr.length()) != baseStr) {
+		OBS_LOG_ERROR("[PathResolver] Full path doesn't start with base path");
+		return false;
+	}
+	
+	// If lengths are equal, paths are identical (allowed)
+	if (fullStr.length() == baseStr.length()) {
+		OBS_LOG_INFO("[PathResolver] Security check result: PASS (identical paths)");
+		return true;
+	}
+	
+	// Check that the next character is a path separator (prevents partial matches)
+	char nextChar = fullStr[baseStr.length()];
+	bool isSeparator = (nextChar == kWindowsSeparator || nextChar == kUnixSeparator);
+	
+	OBS_LOG_INFO("[PathResolver] Security check result: %s (next char: '%c')", 
+		isSeparator ? "PASS" : "FAIL", nextChar);
+	return isSeparator;
+}
+
 std::optional<std::string> PathResolver::toFull(const std::string &relative) const
 {
-	// 入力検証：空、絶対、親ディレクトリ参照は拒否
-	if (relative.empty() || isAbs(relative) || containsParentRef(relative)) {
+	OBS_LOG_INFO("[PathResolver] Resolving relative path: '%s'", relative.c_str());
+	
+	// Input validation: reject empty, absolute paths, or parent directory references
+	if (relative.empty()) {
+		OBS_LOG_ERROR("[PathResolver] Empty relative path provided");
+		return std::nullopt;
+	}
+	
+	if (isAbsolute(relative)) {
+		OBS_LOG_ERROR("[PathResolver] Absolute path rejected: '%s'", relative.c_str());
+		return std::nullopt;
+	}
+	
+	if (containsParentRef(relative)) {
+		OBS_LOG_ERROR("[PathResolver] Path contains parent reference (..) rejected: '%s'", relative.c_str());
 		return std::nullopt;
 	}
 
-	// ルート取得
-	const std::string base = root.root();
-	if (base.empty()) {
+	// Get root directory
+	const std::string baseDir = root.root();
+	OBS_LOG_INFO("[PathResolver] Base directory from root provider: '%s'", baseDir.c_str());
+	if (baseDir.empty()) {
+		OBS_LOG_ERROR("[PathResolver] Root provider returned empty base directory");
 		return std::nullopt;
 	}
 
-	// 結合して正規化
-	const auto full = (stdfs::path(base) / stdfs::path(relative)).lexically_normal();
+	// Combine and normalize paths
+	const auto basePath = stdfs::path(baseDir);
+	const auto fullPath = (basePath / stdfs::path(relative)).lexically_normal();
+	OBS_LOG_INFO("[PathResolver] Combined path before security check: '%s'", fullPath.string().c_str());
 
-	// 念のため、正規化後にまだ絶対/親参照が混入していないか簡易チェック
-	if (full.is_absolute()) {
-		// base が絶対なので normally OK のはずだが、安全側でチェック
-		// （要件に応じてこのチェックは省略可）
+	// Security check: ensure the resolved path stays within base directory
+	if (!isPathTraversalSafe(basePath, fullPath)) {
+		OBS_LOG_ERROR("[PathResolver] Path traversal security check failed for: '%s'", fullPath.string().c_str());
+		return std::nullopt;
 	}
 
-	return full.string(); // UTF-8 前提なら .u8string() でも可
+	OBS_LOG_INFO("[PathResolver] Path resolution successful: '%s' -> '%s'", relative.c_str(), fullPath.string().c_str());
+	return fullPath.string();
 }
 
 } // namespace foxclip::infra_shared::fs

--- a/src/infra_shared/fs/roots/IRootProvider.h
+++ b/src/infra_shared/fs/roots/IRootProvider.h
@@ -6,7 +6,7 @@ namespace foxclip::infra_shared::fs::roots {
 class IRootProvider {
 public:
 	virtual ~IRootProvider() = default;
-	// 末尾セパレータ無しの絶対パス（UTF-8）を返す。失敗時は空文字。
+	// 末尾セパレータ無しの絶対パス（UTF-8）を返す。失敗時は空文字を返す。
 	virtual std::string root() = 0;
 };
 

--- a/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
+++ b/src/infra_shared/fs/roots/ObsConfigRootProvider.cpp
@@ -9,7 +9,7 @@ using foxclip::infra_shared::config::path::IConfigPathProvider;
 ObsConfigRootProvider::ObsConfigRootProvider(std::shared_ptr<IConfigPathProvider> provider)
 	: pathProvider(provider ? std::move(provider) : makeObsConfigPathProvider())
 {
-	// 本体
+	// コンストラクタ本体
 }
 
 std::string ObsConfigRootProvider::root()

--- a/src/infra_shared/plugin/PluginFolderLogger.cpp
+++ b/src/infra_shared/plugin/PluginFolderLogger.cpp
@@ -25,7 +25,7 @@ void logPluginSubfolders(const std::string &pluginDirName)
 	}
 
 	const std::filesystem::path rootPath{*fullOpt};
-	const auto subs = DirectoryLister::listSubdirectories(rootPath);
+	const auto subs = DirectoryLister::listSubDirectories(rootPath);
 
 	OBS_LOG_INFO("[foxclip] Plugin folder listing: %s", fullOpt->c_str());
 	if (subs.empty()) {

--- a/src/infra_shared/startup/EnsurePluginDir.cpp
+++ b/src/infra_shared/startup/EnsurePluginDir.cpp
@@ -2,6 +2,7 @@
 #include "infra_shared/fs/roots/ObsConfigRootProvider.h"
 #include "infra_shared/fs/PathResolver.h"
 #include "infra_shared/fs/FsUtils.h"
+#include "infra_shared/log/ObsLogger.h"
 
 namespace foxclip::infra_shared::startup {
 
@@ -11,28 +12,41 @@ EnsureResult ensureObsWritableDir(const std::string &subdir)
 	using foxclip::infra_shared::fs::PathResolver;
 	using foxclip::infra_shared::fs::createDirs;
 
+	OBS_LOG_INFO("[EnsurePluginDir] Starting directory resolution for subdir: '%s'", subdir.c_str());
+
 	// 1) OBS ルート取得（…/plugin_config/<plugin>）
 	ObsConfigRootProvider root;
 	const std::string base = root.root();
-	if (base.empty())
+	OBS_LOG_INFO("[EnsurePluginDir] OBS config root resolved to: '%s'", base.c_str());
+	if (base.empty()) {
+		OBS_LOG_ERROR("[EnsurePluginDir] Failed to resolve OBS config root");
 		return {false, {}, "failed to resolve OBS config root"};
+	}
 
 	// 2) 相対 subdir をルート配下のフルパスへ正規化
 	PathResolver resolver(root);
 	const auto fullOpt = resolver.toFull(subdir);
-	if (!fullOpt || fullOpt->empty())
+	if (!fullOpt || fullOpt->empty()) {
+		OBS_LOG_ERROR("[EnsurePluginDir] Path resolution failed for subdir: '%s'", subdir.c_str());
 		return {false, {}, "invalid subdir (absolute or contains ..)"};
+	}
 
 	const std::string &full = *fullOpt;
+	OBS_LOG_INFO("[EnsurePluginDir] Full path resolved to: '%s'", full.c_str());
 
 	std::error_code ec;
+	OBS_LOG_INFO("[EnsurePluginDir] Attempting to create directory: '%s'", full.c_str());
 	if (!createDirs(full, ec)) {
 		std::string msg = "failed to create '" + subdir + "'";
-		if (ec)
+		if (ec) {
 			msg += ": " + ec.message();
+			OBS_LOG_ERROR("[EnsurePluginDir] Directory creation failed: %s", ec.message().c_str());
+		}
+		OBS_LOG_ERROR("[EnsurePluginDir] %s", msg.c_str());
 		return {false, {}, msg};
 	}
 
+	OBS_LOG_INFO("[EnsurePluginDir] Directory creation successful: '%s'", full.c_str());
 	return {true, full, {}};
 }
 

--- a/src/public_api/recorder/FoxclipRecorderApi.c
+++ b/src/public_api/recorder/FoxclipRecorderApi.c
@@ -1,5 +1,6 @@
-#include "foxclip/recorder/start.h"
+#include "foxclip/recording/start.h"
 #include "foxclip/plugin_api.h"
+#include <string.h>
 
 int FOXCLIP_CALL foxclipRecordStart(const FoxclipRecorderStartOptions *opts)
 {
@@ -15,8 +16,8 @@ int FOXCLIP_CALL foxclipRecordStart(const FoxclipRecorderStartOptions *opts)
 		size_t n = opts->size;
 		if (n > sizeof(FoxclipRecorderStartOptions))
 			n = sizeof(FoxclipRecorderStartOptions);
-		/* 安全な逐次コピー（memcpyでもOK。ここは明示的に） */
-		local = *opts; /* C の単純代入はサイズ一致前提だが、必要ならmemcpyに置換 */
+		/* 安全な逐次コピー: size に基づいて必要な分だけコピー */
+		memcpy(&local, opts, n);
 	}
 	return foxclipApi->recordStart(&local);
 #else

--- a/src/public_api/recorder/FoxclipRecorderApi.c
+++ b/src/public_api/recorder/FoxclipRecorderApi.c
@@ -1,0 +1,27 @@
+#include "foxclip/recorder/start.h"
+#include "foxclip/plugin_api.h"
+
+int FOXCLIP_CALL foxclipRecordStart(const FoxclipRecorderStartOptions *opts)
+{
+#if defined(FOXCLIP_USE_VTABLE)
+	if (!foxclipApi)
+		return FOXCLIP_RECORDER_E_NOT_SUPPORTED;
+	if (!foxclipApi->recordStart)
+		return FOXCLIP_RECORDER_E_NOT_SUPPORTED;
+
+	FoxclipRecorderStartOptions local = FOXCLIP_RECORDER_START_OPTIONS_INIT;
+	if (opts) {
+		/* size ゲーティング: 受け取れた範囲だけコピー */
+		size_t n = opts->size;
+		if (n > sizeof(FoxclipRecorderStartOptions))
+			n = sizeof(FoxclipRecorderStartOptions);
+		/* 安全な逐次コピー（memcpyでもOK。ここは明示的に） */
+		local = *opts; /* C の単純代入はサイズ一致前提だが、必要ならmemcpyに置換 */
+	}
+	return foxclipApi->recordStart(&local);
+#else
+	/* vtable を使わないビルド構成では未サポート */
+	(void)opts;
+	return FOXCLIP_RECORDER_E_NOT_SUPPORTED;
+#endif
+}


### PR DESCRIPTION
- #60 
## コーディングルール
 
このコーディングルールに従っているかをチェックすること。
* **anyは使わない**

  * 対象は **`std::any` 禁止** の意味、と明記してください。
  * 代替: 具体型／`std::variant`／テンプレートで表現。レビューは `[必須]`（型安全性）で指摘。

* **命名**

  * 型／クラス名: `UpperCamel`、関数・変数: `lowerCamel` を「ファイル全域で統一」。
  * 定数は `kUpperCamel`（例: `kMaxSize`）を推奨（衝突回避・視認性）。
  * テスト用の fixture, matcher も命名規約の例外にしない（統一が楽）。

* **予約識別子（アンダースコア関連）**

  * 「アンダースコア＋大文字で始まる名前」「連続する二つのアンダースコア」は**予約**なので**全面禁止**。
  * **大域（グローバル）名前空間でアンダースコア始まり**も**禁止**（標準予約）。
  * これらは\*\*`[必須]`違反\*\*として扱い、機械検出を必須化（後述）。

* **std 名前空間**

  * **`namespace std { ... }` での追加・変更は禁止（未定義動作）**。
  * ただし標準が許容する**ユーザー定義型に対する既存テンプレートの**明示的**特殊化**（例: `std::hash<MyType>`、`std::formatter<MyType>`）は可。
  * 可否を規約に明文化（「フル特殊化のみ可・部分特殊化不可」など）。

* **引数は 3～5 個を目安**

  * 6 個以上は**構造体に束ねる** or **Builder** を推奨（レビューは `[推奨]`）。
  * 「可変長引数」「多数の bool 引数」も原則禁止。意味不明瞭なら `[必須]` で差戻し。

* **モジュール化（infra_shared/**）**

  * **複数モジュールから使う可能性のある処理は** `infra_shared/<機能区分>/` に配置。
  * インタフェースは最小依存（PIMPL/前方宣言）＋ **安定 ABI/ヘッダ** を意識。
  * CMake は `infra_shared_*` を**静的ライブラリ**に分離し、**依存の向き**（アプリ→shared）を厳守。

<!-- for GitHub Copilot review rule -->
 
[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）
 
<!-- for GitHub Copilot review rule-->